### PR TITLE
Fixed time package tests

### DIFF
--- a/time/time_test.go
+++ b/time/time_test.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// time.Now mock
+var now = time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)
+
 func TestStartOfDay(t *testing.T) {
 	type args struct {
 		input time.Time
@@ -346,7 +349,7 @@ func TestConvertToTimeZone(t *testing.T) {
 				location: "Local",
 			},
 			wantErr: false,
-			want:    time.Date(2023, 12, 25, 15, 0, 0, 0, time.UTC).In(time.Now().Location()),
+			want:    time.Date(2023, 12, 25, 15, 0, 0, 0, time.UTC).In(now.Location()),
 		},
 		{
 			name: "Convert PST to IST",
@@ -445,7 +448,7 @@ func TestCalculateAge(t *testing.T) {
 		{
 			name: "Birthday today, age remains the same",
 			args: args{
-				birthDate: time.Date(time.Now().Year()-30, time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC),
+				birthDate: time.Date(now.Year()-30, now.Month(), now.Day(), 0, 0, 0, 0, time.UTC),
 			},
 			want: 30,
 		},
@@ -475,7 +478,13 @@ func TestCalculateAge(t *testing.T) {
 			args: args{
 				birthDate: time.Date(2000, 2, 29, 0, 0, 0, 0, time.UTC),
 			},
-			want: time.Now().Year() - 2000,
+			want: func() int {
+				leapYearAge := now.Year() - 2000
+				if now.Before(time.Date(now.Year(), 2, 29, 0, 0, 0, 0, time.UTC)) {
+					leapYearAge--
+				}
+				return leapYearAge
+			}(),
 		},
 		{
 			name: "Future date, invalid age",


### PR DESCRIPTION
### Description:
closes #86 

The time package had incorrect tests. The main issue was using time.Now() directly in the test cases which made the tests flaky and dependent on the exact time the test is executed.

### Checklists:
* [x] Tests passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test cases with a fixed reference time to improve test consistency and determinism
	- Replaced dynamic time references with a static mock time variable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->