### PR TITLE
Add basic benchmarks

### DIFF
--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -116,3 +116,54 @@ func TestSafeCacheWrapperConcurrency(t *testing.T) {
 		}
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func fib(n int) int {
+	if n <= 1 {
+		return n
+	}
+	return fib(n-1) + fib(n-2)
+}
+
+func BenchmarkFib(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = fib(30)
+	}
+}
+
+func BenchmarkCachedFib(b *testing.B) {
+	cachedFib := CacheWrapper(fib)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cachedFib(30)
+	}
+}
+
+func BenchmarkSafeCachedFib(b *testing.B) {
+	cachedFib := SafeCacheWrapper(fib)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cachedFib(30)
+	}
+}
+
+func BenchmarkConcurrentSafeCachedFib(b *testing.B) {
+	cachedFib := SafeCacheWrapper(fib)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = cachedFib(30)
+		}
+	})
+}

--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -122,22 +122,22 @@ func TestSafeCacheWrapperConcurrency(t *testing.T) {
 // ================================================================================
 
 func fib(n int) int {
-    if n <= 1 {
-        return n
-    }
-    a, b := 0, 1
-    for i := 2; i <= n; i++ {
-        a, b = b, a+b
-    }
-    return b
+	if n <= 1 {
+		return n
+	}
+	a, b := 0, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, a+b
+	}
+	return b
 }
 
 func BenchmarkFib(b *testing.B) {
-    b.ReportAllocs()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _ = fib(30)
-    }
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = fib(30)
+	}
 }
 
 func BenchmarkCachedFib(b *testing.B) {

--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -122,18 +122,22 @@ func TestSafeCacheWrapperConcurrency(t *testing.T) {
 // ================================================================================
 
 func fib(n int) int {
-	if n <= 1 {
-		return n
-	}
-	return fib(n-1) + fib(n-2)
+    if n <= 1 {
+        return n
+    }
+    a, b := 0, 1
+    for i := 2; i <= n; i++ {
+        a, b = b, a+b
+    }
+    return b
 }
 
 func BenchmarkFib(b *testing.B) {
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = fib(30)
-	}
+    b.ReportAllocs()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _ = fib(30)
+    }
 }
 
 func BenchmarkCachedFib(b *testing.B) {

--- a/ctxutils/ctxutils_test.go
+++ b/ctxutils/ctxutils_test.go
@@ -2,8 +2,11 @@ package ctxutils
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
+
+// TODO: these can be written as a table test
 
 func TestSetStringValueAndGetStringValue(t *testing.T) {
 	ctx := context.Background()
@@ -65,5 +68,37 @@ func TestSetIntValueWithWrongKey(t *testing.T) {
 
 	if ok {
 		t.Errorf("Expected value not to be found, but it was.")
+	}
+}
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkSettingAndGettingStringKey(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	key := ContextKeyString{Key: "id"}
+
+	for i := 0; i < b.N; i++ {
+		ctx = SetStringValue(ctx, key, fmt.Sprintf("value-%d", i))
+		_, _ = GetStringValue(ctx, key)
+	}
+}
+
+func BenchmarkSettingAndGettingIntKey(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	key := ContextKeyInt{Key: 0}
+
+	for i := 0; i < b.N; i++ {
+		ctx = SetIntValue(ctx, key, i)
+		_, _ = GetIntValue(ctx, key)
 	}
 }

--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -75,3 +75,31 @@ func TestRandomAddress(t *testing.T) {
 		t.Errorf("Generated address %v does not match the expected format", address)
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkGenerateUUID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = RandomUUID()
+	}
+}
+
+func BenchmarkRandomDate(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = RandomDate()
+	}
+}
+
+func BenchmarkRandomPhoneNumber(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = RandomPhoneNumber()
+	}
+}
+
+func BenchmarkRandomAddress(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = RandomAddress()
+	}
+}

--- a/fsutils/fsutils_test.go
+++ b/fsutils/fsutils_test.go
@@ -1,6 +1,7 @@
 package fsutils
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -333,7 +334,11 @@ func TestDirsIdentical(t *testing.T) {
 	})
 
 	t.Run("nested directories", func(t *testing.T) {
-		dir1, dir2 := setupNestedDirs(t)
+		dir1, dir2, err := setupNestedDirs()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		defer os.RemoveAll(dir1)
 		defer os.RemoveAll(dir2)
 
@@ -347,54 +352,47 @@ func TestDirsIdentical(t *testing.T) {
 	})
 }
 
-func setupNestedDirs(t *testing.T) (string, string) {
-	// Create temporary directories for testing
-	tempDir1, err := os.MkdirTemp("", "nestedtestdir1")
+func setupNestedDirs() (string, string, error) {
+	tempDir1, err := os.MkdirTemp("", "nestedtestdir1_")
 	if err != nil {
-		t.Fatal(err)
+		return "", "", fmt.Errorf("failed to create tempDir1: %w", err)
 	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(tempDir1)
+		}
+	}()
 
-	tempDir2, err := os.MkdirTemp("", "nestedtestdir2")
+	tempDir2, err := os.MkdirTemp("", "nestedtestdir2_")
 	if err != nil {
-		t.Fatal(err)
+		os.RemoveAll(tempDir1)
+		return "", "", fmt.Errorf("failed to create tempDir2: %w", err)
 	}
-
-	// Create nested directory structure in both directories
-	nestedDirs := []string{
-		"dir1",
-		"dir1/dir2",
-		"dir1/dir2/dir3",
-	}
-
-	for _, dir := range nestedDirs {
-		if err := os.MkdirAll(filepath.Join(tempDir1, dir), 0755); err != nil {
-			t.Fatal(err)
+	defer func() {
+		if err != nil {
+			os.RemoveAll(tempDir2)
 		}
-		if err := os.MkdirAll(filepath.Join(tempDir2, dir), 0755); err != nil {
-			t.Fatal(err)
-		}
+	}()
+
+	files := map[string]string{
+		"dir1/file1.txt":           "file1",
+		"dir1/dir2/file2.txt":      "file2",
+		"dir1/dir2/dir3/file3.txt": "file3",
 	}
 
-	// Create some test files in the nested directories
-	files := []struct {
-		path     string
-		contents string
-	}{
-		{path: filepath.Join(tempDir1, "dir1/file1.txt"), contents: "file1"},
-		{path: filepath.Join(tempDir1, "dir1/dir2/file2.txt"), contents: "file2"},
-		{path: filepath.Join(tempDir1, "dir1/dir2/dir3/file3.txt"), contents: "file3"},
-	}
-
-	for _, file := range files {
-		if err := os.WriteFile(file.path, []byte(file.contents), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(tempDir2, file.path[len(tempDir1):]), []byte(file.contents), 0644); err != nil {
-			t.Fatal(err)
+	for _, base := range []string{tempDir1, tempDir2} {
+		for relPath, content := range files {
+			fullPath := filepath.Join(base, relPath)
+			if err = os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+				return "", "", fmt.Errorf("failed to create directory for %s: %w", fullPath, err)
+			}
+			if err = os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+				return "", "", fmt.Errorf("failed to write file %s: %w", fullPath, err)
+			}
 		}
 	}
 
-	return tempDir1, tempDir2
+	return tempDir1, tempDir2, nil
 }
 
 func TestGetFileMetadata(t *testing.T) {
@@ -499,4 +497,126 @@ func TestGetFileMetadata(t *testing.T) {
 			t.Error("Expected symlink mode")
 		}
 	})
+}
+
+// ================================================================================
+// ### BENCMARKS
+// ================================================================================
+
+func BenchmarkFormatFileSize(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = FormatFileSize(int64(i))
+	}
+}
+
+func BenchmarkFindFiles(b *testing.B) {
+	tempDir, err := os.MkdirTemp("", "testdir")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	for i := 0; i < 100; i++ {
+		filePath := filepath.Join(tempDir, fmt.Sprintf("%d.txt", i))
+		if err := os.WriteFile(filePath, []byte{}, 0644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = FindFiles(tempDir, ".txt")
+	}
+}
+
+func BenchmarkGetDirectorySize(b *testing.B) {
+	tempDir, err := os.MkdirTemp("", "testdir")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	for i := 0; i < 100; i++ {
+		filePath := filepath.Join(tempDir, fmt.Sprintf("%d.txt", i))
+		data := make([]byte, 1024) // 1 KB per file
+		if _, err := rand.Read(data); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(filePath, data, 0644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = GetDirectorySize(tempDir)
+	}
+}
+
+func BenchmarkFilesIdentical(b *testing.B) {
+	tempDir, err := os.MkdirTemp("", "testdir")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	file1 := filepath.Join(tempDir, "file1.txt")
+	file2 := filepath.Join(tempDir, "file2.txt")
+
+	data := make([]byte, 1024)
+	if _, err := rand.Read(data); err != nil {
+		b.Fatal(err)
+	}
+
+	if err := os.WriteFile(file1, data, 0644); err != nil {
+		b.Fatal(err)
+	}
+	if err := os.WriteFile(file2, data, 0644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = FilesIdentical(file1, file2)
+	}
+}
+
+func BenchmarkDirsIdentical(b *testing.B) {
+	dir1, dir2, err := setupNestedDirs()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = DirsIdentical(dir1, dir2)
+	}
+}
+
+func BenchmarkGetFileMetadata(b *testing.B) {
+	tempDir, err := os.MkdirTemp("", "testdir")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	filePath := filepath.Join(tempDir, "testfile.txt")
+	if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = GetFileMetadata(filePath)
+	}
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -101,9 +101,10 @@ func TestLogger(t *testing.T) {
 // ================================================================================
 
 func BenchmarkLogger(b *testing.B) {
+	logger := logging.NewLogger("Test", logging.INFO, nil)
 	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		logger := logging.NewLogger("Test", logging.INFO, nil)
 		logger.Info("This is an info message")
 	}
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -95,3 +95,15 @@ func TestLogger(t *testing.T) {
 		})
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkLogger(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		logger := logging.NewLogger("Test", logging.INFO, nil)
+		logger.Info("This is an info message")
+	}
+}

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -620,3 +620,40 @@ func TestLCM(t *testing.T) {
 		})
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkIntPow(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		IntPow(i, 10)
+	}
+}
+
+func BenchmarkFactorial(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		Factorial(i % 20) // Factorial of numbers 0 to 19
+	}
+}
+
+func BenchmarkGCD(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		GCD(i, i+1)
+	}
+}
+
+func BenchmarkLCM(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		LCM(i, i+1)
+	}
+}

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -629,8 +629,13 @@ func BenchmarkIntPow(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 
+	bases := []int{2, 3, 4, 5}
+	exponents := []int{2, 3, 4}
+
 	for i := 0; i < b.N; i++ {
-		IntPow(i, 10)
+		base := bases[i%len(bases)]
+		exp := exponents[i%len(exponents)]
+		IntPow(base, exp)
 	}
 }
 

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -638,7 +638,7 @@ func BenchmarkFactorial(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		Factorial(i % 20) // Factorial of numbers 0 to 19
+		_, _ = Factorial(i % 20) // Factorial of numbers 0 to 19
 	}
 }
 

--- a/rand/rand_test.go
+++ b/rand/rand_test.go
@@ -351,32 +351,38 @@ func BenchmarkStringWithLength(b *testing.B) {
 	}
 }
 
+var benchArray = make([]int, 1000)
+
+func init() {
+    for i := 0; i < 1000; i++ {
+        benchArray[i] = i
+    }
+}
+
 func BenchmarkPick(b *testing.B) {
-	array := make([]int, 1000)
-	for i := 0; i < 1000; i++ {
-		array[i] = i
-	}
+    array := make([]int, len(benchArray))
+    copy(array, benchArray)
 
-	b.ReportAllocs()
-	b.ResetTimer()
+    b.ReportAllocs()
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		_, _ = Pick(array)
-	}
+    for i := 0; i < b.N; i++ {
+        _, _ = Pick(array)
+    }
 }
 
 func BenchmarkShuffle(b *testing.B) {
-	array := make([]int, 1000)
-	for i := 0; i < 1000; i++ {
-		array[i] = i
-	}
+    array := make([]int, 1000)
+    for i := 0; i < 1000; i++ {
+        array[i] = i
+    }
 
-	b.ReportAllocs()
-	b.ResetTimer()
+    b.ReportAllocs()
+    b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		_ = Shuffle(array)
-	}
+    for i := 0; i < b.N; i++ {
+        _ = Shuffle(array)
+    }
 }
 
 func BenchmarkStringWithCharset(b *testing.B) {

--- a/rand/rand_test.go
+++ b/rand/rand_test.go
@@ -1,6 +1,8 @@
 package rand
 
 import (
+	"math/rand"
+	randv2 "math/rand/v2"
 	"strings"
 	"testing"
 )
@@ -289,4 +291,97 @@ func contains[T comparable](slice []T, item T) bool {
 		}
 	}
 	return false
+}
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+// The crypto/rand package is secure but slow compared to math/rand and math/rand/v2
+
+func BenchmarkNumberCrypto(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = Number()
+	}
+}
+
+// Using math/rand
+func numberMathRand() (int64, error) {
+	return rand.Int63(), nil
+}
+
+func BenchmarkNumberMath(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = numberMathRand()
+	}
+}
+
+// Using math/rand/v2
+func numberMathRandV2() (int64, error) {
+	return randv2.Int64(), nil
+}
+
+func BenchmarkNumberMathV2(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = numberMathRandV2()
+	}
+}
+
+func BenchmarkNumberInRange(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = NumberInRange(0, 1000)
+	}
+}
+
+func BenchmarkString(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = String()
+	}
+}
+
+func BenchmarkStringWithLength(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = StringWithLength(100)
+	}
+}
+
+func BenchmarkPick(b *testing.B) {
+	array := make([]int, 1000)
+	for i := 0; i < 1000; i++ {
+		array[i] = i
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = Pick(array)
+	}
+}
+
+func BenchmarkShuffle(b *testing.B) {
+	array := make([]int, 1000)
+	for i := 0; i < 1000; i++ {
+		array[i] = i
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = Shuffle(array)
+	}
+}
+
+func BenchmarkStringWithCharset(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = StringWithCharset(1000, DefaultCharset)
+	}
 }

--- a/rand/rand_test.go
+++ b/rand/rand_test.go
@@ -354,35 +354,35 @@ func BenchmarkStringWithLength(b *testing.B) {
 var benchArray = make([]int, 1000)
 
 func init() {
-    for i := 0; i < 1000; i++ {
-        benchArray[i] = i
-    }
+	for i := 0; i < 1000; i++ {
+		benchArray[i] = i
+	}
 }
 
 func BenchmarkPick(b *testing.B) {
-    array := make([]int, len(benchArray))
-    copy(array, benchArray)
+	array := make([]int, len(benchArray))
+	copy(array, benchArray)
 
-    b.ReportAllocs()
-    b.ResetTimer()
+	b.ReportAllocs()
+	b.ResetTimer()
 
-    for i := 0; i < b.N; i++ {
-        _, _ = Pick(array)
-    }
+	for i := 0; i < b.N; i++ {
+		_, _ = Pick(array)
+	}
 }
 
 func BenchmarkShuffle(b *testing.B) {
-    array := make([]int, 1000)
-    for i := 0; i < 1000; i++ {
-        array[i] = i
-    }
+	array := make([]int, 1000)
+	for i := 0; i < 1000; i++ {
+		array[i] = i
+	}
 
-    b.ReportAllocs()
-    b.ResetTimer()
+	b.ReportAllocs()
+	b.ResetTimer()
 
-    for i := 0; i < b.N; i++ {
-        _ = Shuffle(array)
-    }
+	for i := 0; i < b.N; i++ {
+		_ = Shuffle(array)
+	}
 }
 
 func BenchmarkStringWithCharset(b *testing.B) {

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -1,7 +1,9 @@
 package slice
 
 import (
+	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +52,56 @@ func TestRemoveDuplicateInt(t *testing.T) {
 				t.Errorf("RemoveDuplicateInt() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func generateStrings(n int) []string {
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?/~`"
+	data := make([]string, n)
+
+	for i := 0; i < n; i++ {
+		strLen := (i % 10) + 5 // Generate strings of length 5-14
+		var strBuilder strings.Builder
+		for j := 0; j < strLen; j++ {
+			strBuilder.WriteByte(charset[(i+j)%len(charset)])
+		}
+		data[i] = strBuilder.String()
+	}
+	return data
+}
+
+func generateRandomInts(n int) []int {
+	r := rand.New(rand.NewSource(99))
+
+	data := make([]int, n)
+	for i := 0; i < n; i++ {
+		data[i] = r.Intn(1000)
+	}
+	return data
+}
+
+func BenchmarkRemoveDuplicateStrings(b *testing.B) {
+	data := generateStrings(100000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		RemoveDuplicateStr(data)
+	}
+}
+
+func BenchmarkRemoveDuplicateInts(b *testing.B) {
+	data := generateRandomInts(100000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		RemoveDuplicateInt(data)
 	}
 }

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -506,3 +506,80 @@ func TestCommonSuffix(t *testing.T) {
 		}
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkSubstringSearch(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		SubstringSearch("find this in a string", "this", SubstringSearchOptions{
+			CaseInsensitive: false,
+			ReturnIndexes:   false,
+		})
+	}
+}
+
+func BenchmarkToTitle(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ToTitle("lower case", []string{})
+	}
+}
+
+func BenchmarkTokenize(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Tokenize("This is a custom-tokenization!example", "-!")
+	}
+}
+
+func BenchmarkRot13Encode(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Rot13Encode("Hello, World!")
+	}
+}
+
+func BenchmarkCaesarEncrypt(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		CaesarEncrypt("Hello, World!", 3)
+	}
+}
+
+func BenchmarkRunLengthEncode(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		RunLengthEncode("aaabbccccdd")
+	}
+}
+
+func BenchmarkIsValidEmail(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		IsValidEmail("example@email.com")
+	}
+}
+
+func BenchmarkReverse(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Reverse("hello")
+	}
+}
+
+func BenchmarkCommonPrefix(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		CommonPrefix("nation", "national", "nasty")
+	}
+}
+
+func BenchmarkCommonSuffix(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		CommonSuffix("testing", "running", "jumping")
+	}
+}

--- a/structs/structs_test.go
+++ b/structs/structs_test.go
@@ -93,3 +93,45 @@ func TestCompareStructs(t *testing.T) {
 		})
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkCompareStructsSimple(b *testing.B) {
+	old := Test{Name: "example", Age: 10, IsAdult: false}
+	new := Test{Name: "example - updated", Age: 18, IsAdult: true}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := CompareStructs(old, new)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCompareStructsComplex(b *testing.B) {
+	old := ComplexTest{
+		Data:      Test{Name: "example1", Age: 25, IsAdult: true},
+		UpdatedOn: time.Date(2024, 10, 22, 0, 0, 0, 0, time.UTC),
+		History:   []string{"user1", "user2"},
+	}
+	new := ComplexTest{
+		Data:      Test{Name: "example1", Age: 26, IsAdult: true},
+		UpdatedOn: time.Date(2024, 10, 22, 0, 1, 0, 0, time.UTC),
+		History:   []string{"user1", "user2", "user3"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := CompareStructs(old, new)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/templates/html_test.go
+++ b/templates/html_test.go
@@ -207,3 +207,26 @@ func TestRenderHTML(t *testing.T) {
 		})
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkRenderHTML(b *testing.B) {
+	tmpl, _ := htmlTemplate.New("htmlTestTemplate").Funcs(GetCustomFuncMap()).Parse(normalizeWhitespace(htmlTestTemplate1))
+	data := struct {
+		Name string
+		Date time.Time
+	}{
+		Name: "alice",
+		Date: time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var sb strings.Builder
+		_ = tmpl.Execute(&sb, data)
+	}
+}

--- a/templates/text_test.go
+++ b/templates/text_test.go
@@ -170,3 +170,21 @@ func TestRenderText(t *testing.T) {
 		})
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkRenderText(b *testing.B) {
+	data := struct {
+		Name string
+		Date time.Time
+	}{
+		Name: "alice",
+		Date: time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, _ = RenderText(testTemplate1, data)
+	}
+}

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -406,3 +406,42 @@ func TestGetQueryParamError(t *testing.T) {
 		t.Errorf("GetQueryParam() error = %v, want %v", err.Error(), testError.want)
 	}
 }
+
+// ================================================================================
+// ### BENCHMARKS
+// ================================================================================
+
+func BenchmarkBuildURL(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		BuildURL("http", "example.com", "onePath", map[string]string{"queryParamOne": "valueQueryParamOne"})
+	}
+}
+
+func BenchmarkAddQueryParams(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		AddQueryParams("http://example.com", map[string]string{"queryParamOne": "valueQueryParamOne"})
+	}
+}
+
+func BenchmarkIsValidURL(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		IsValidURL("http://example.com", []string{"http", "https"})
+	}
+}
+
+func BenchmarkExtractDomain(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ExtractDomain("http://example.com")
+	}
+}
+
+func BenchmarkGetQueryParam(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		GetQueryParam("http://example.com?key=value", "key")
+	}
+}

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -414,14 +414,14 @@ func TestGetQueryParamError(t *testing.T) {
 func BenchmarkBuildURL(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		BuildURL("http", "example.com", "onePath", map[string]string{"queryParamOne": "valueQueryParamOne"})
+		_, _ = BuildURL("http", "example.com", "onePath", map[string]string{"queryParamOne": "valueQueryParamOne"})
 	}
 }
 
 func BenchmarkAddQueryParams(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		AddQueryParams("http://example.com", map[string]string{"queryParamOne": "valueQueryParamOne"})
+		_, _ = AddQueryParams("http://example.com", map[string]string{"queryParamOne": "valueQueryParamOne"})
 	}
 }
 
@@ -435,13 +435,13 @@ func BenchmarkIsValidURL(b *testing.B) {
 func BenchmarkExtractDomain(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ExtractDomain("http://example.com")
+		_, _ = ExtractDomain("http://example.com")
 	}
 }
 
 func BenchmarkGetQueryParam(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		GetQueryParam("http://example.com?key=value", "key")
+		_, _ = GetQueryParam("http://example.com?key=value", "key")
 	}
 }


### PR DESCRIPTION
### Description:
Not all functions needed benchmarks; I've refrained from adding any for wrappers around the standard library, such as boolean, maps, and pointers, as they would mostly measure the overhead of calling Go's standard library functions.

### Checklist:  
- [x] **Tests Passing**: Verify by running `make test`.  
- [x] **Golint Passing**: Confirm by running `make lint`.  

#### If added a new utility function or updated existing function logic:
* [ ] Updated [EXAMPLES.md](/EXAMPLES.md)
* [ ] Updated [readME.md](/readME.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded the performance test suite across multiple areas, including caching, context management, random data generation, file system operations, logging, mathematics, string manipulations, data structure comparisons, and template rendering.
  - Enhanced error handling in file system setups to improve test robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->