### PR TITLE
feat: Add nlreturn linter and clean up code formatting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,3 +9,11 @@ linters:
     - errcheck
     - goimports
     - gofmt
+    - nlreturn
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+          - nlreturn
+

--- a/boolean/boolean.go
+++ b/boolean/boolean.go
@@ -43,6 +43,7 @@ func AllTrue(values []bool) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -63,6 +64,7 @@ func AnyTrue(values []bool) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -83,6 +85,7 @@ func NoneTrue(values []bool) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -99,6 +102,7 @@ func CountTrue(values []bool) int {
 			count++ // Increment for each true value.
 		}
 	}
+
 	return count
 }
 
@@ -115,6 +119,7 @@ func CountFalse(values []bool) int {
 			count++ // Increment for each false value.
 		}
 	}
+
 	return count
 }
 
@@ -136,6 +141,7 @@ func Equal(values ...bool) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -152,6 +158,7 @@ func And(values []bool) bool {
 			return false // Short-circuit if any value is false.
 		}
 	}
+
 	return len(values) > 0 // Ensure the slice is not empty.
 }
 
@@ -168,5 +175,6 @@ func Or(values []bool) bool {
 			return true // Short-circuit if any value is true.
 		}
 	}
+
 	return false // No true values found, or the slice is empty.
 }

--- a/caching/caching.go
+++ b/caching/caching.go
@@ -9,6 +9,7 @@ import "sync"
 // CacheWrapper is a non-thread-safe caching decorator.
 func CacheWrapper[T comparable, R any](fn func(T) R) func(T) R {
 	cache := make(map[T]R)
+
 	return func(input T) R {
 		// Check if the result is already cached
 		if result, exists := cache[input]; exists {
@@ -17,6 +18,7 @@ func CacheWrapper[T comparable, R any](fn func(T) R) func(T) R {
 		// Call the function and store the result in the cache
 		result := fn(input)
 		cache[input] = result
+
 		return result
 	}
 }
@@ -24,6 +26,7 @@ func CacheWrapper[T comparable, R any](fn func(T) R) func(T) R {
 // SafeCacheWrapper is a thread-safe caching decorator.
 func SafeCacheWrapper[T comparable, R any](fn func(T) R) func(T) R {
 	var cache sync.Map
+
 	return func(input T) R {
 		// Check if the result is already cached
 		if result, exists := cache.Load(input); exists {
@@ -32,6 +35,7 @@ func SafeCacheWrapper[T comparable, R any](fn func(T) R) func(T) R {
 		// Call the function and store the result in the cache
 		result := fn(input)
 		cache.Store(input, result)
+
 		return result
 	}
 }

--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -14,6 +14,7 @@ func TestCacheWrapper(t *testing.T) {
 		for i := 2; i <= n; i++ {
 			result.Mul(result, big.NewInt(int64(i)))
 		}
+
 		return result
 	}
 
@@ -129,6 +130,7 @@ func fib(n int) int {
 	for i := 2; i <= n; i++ {
 		a, b = b, a+b
 	}
+
 	return b
 }
 

--- a/ctxutils/ctxutils.go
+++ b/ctxutils/ctxutils.go
@@ -18,6 +18,7 @@ func SetStringValue(ctx context.Context, key ContextKeyString, value string) con
 
 func GetStringValue(ctx context.Context, key ContextKeyString) (string, bool) {
 	value, ok := ctx.Value(key).(string)
+
 	return value, ok
 }
 
@@ -27,5 +28,6 @@ func SetIntValue(ctx context.Context, key ContextKeyInt, value int) context.Cont
 
 func GetIntValue(ctx context.Context, key ContextKeyInt) (int, bool) {
 	value, ok := ctx.Value(key).(int)
+
 	return value, ok
 }

--- a/errutils/errutils.go
+++ b/errutils/errutils.go
@@ -54,5 +54,6 @@ func (e *ErrorAggregator) Error() error {
 func (e *ErrorAggregator) ErrorList() []error {
 	result := make([]error, len(e.errors))
 	copy(result, e.errors)
+
 	return result
 }

--- a/fsutils/fsutils_test.go
+++ b/fsutils/fsutils_test.go
@@ -366,6 +366,7 @@ func setupNestedDirs() (string, string, error) {
 	tempDir2, err := os.MkdirTemp("", "nestedtestdir2_")
 	if err != nil {
 		os.RemoveAll(tempDir1)
+
 		return "", "", fmt.Errorf("failed to create tempDir2: %w", err)
 	}
 	defer func() {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -55,6 +55,7 @@ func NewLogger(prefix string, minLevel LogLevel, output io.Writer) *Logger {
 	if output == nil {
 		output = os.Stdout // Default to standard output
 	}
+
 	return &Logger{
 		minLevel: minLevel,
 		prefix:   prefix,

--- a/math/math.go
+++ b/math/math.go
@@ -23,6 +23,7 @@ func Abs[T signedNumber](x T) T {
 	if x < 0 {
 		return -x
 	}
+
 	return x
 }
 
@@ -34,6 +35,7 @@ func Sign[T signedNumber](x T) int {
 	} else if x < 0 {
 		return -1
 	}
+
 	return 0
 }
 
@@ -42,6 +44,7 @@ func Min[T number](x, y T) T {
 	if x < y {
 		return x
 	}
+
 	return y
 }
 
@@ -50,6 +53,7 @@ func Max[T number](x, y T) T {
 	if x > y {
 		return x
 	}
+
 	return y
 }
 
@@ -61,6 +65,7 @@ func Clamp[T number](min, max, value T) T {
 	} else if value > max {
 		return max
 	}
+
 	return value
 }
 
@@ -129,6 +134,7 @@ func Factorial(x int) (int, error) {
 	for i := 2; i <= x; i++ {
 		result *= i
 	}
+
 	return result, nil
 }
 
@@ -150,5 +156,6 @@ func LCM(x, y int) int {
 	if x == 0 || y == 0 {
 		return 0
 	}
+
 	return (x / GCD(x, y)) * y
 }

--- a/pointers/common.go
+++ b/pointers/common.go
@@ -8,6 +8,7 @@ func DefaultIfNil[T any](ptr *T, defaultVal T) T {
 	if ptr == nil {
 		return defaultVal
 	}
+
 	return *ptr
 }
 
@@ -17,6 +18,7 @@ func NullableBool(b *bool) bool {
 	if b == nil {
 		return false
 	}
+
 	return *b
 }
 
@@ -26,5 +28,6 @@ func NullableTime(t *time.Time) time.Time {
 	if t == nil {
 		return time.Time{}
 	}
+
 	return *t
 }

--- a/pointers/numeric.go
+++ b/pointers/numeric.go
@@ -6,6 +6,7 @@ func NullableInt(i *int) int {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -15,6 +16,7 @@ func NullableInt8(i *int8) int8 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -24,6 +26,7 @@ func NullableInt16(i *int16) int16 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -33,6 +36,7 @@ func NullableInt32(i *int32) int32 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -42,6 +46,7 @@ func NullableInt64(i *int64) int64 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -51,6 +56,7 @@ func NullableUint(i *uint) uint {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -60,6 +66,7 @@ func NullableUint8(i *uint8) uint8 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -69,6 +76,7 @@ func NullableUint16(i *uint16) uint16 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -78,6 +86,7 @@ func NullableUint32(i *uint32) uint32 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -87,6 +96,7 @@ func NullableUint64(i *uint64) uint64 {
 	if i == nil {
 		return 0
 	}
+
 	return *i
 }
 
@@ -96,6 +106,7 @@ func NullableFloat32(f *float32) float32 {
 	if f == nil {
 		return 0.0
 	}
+
 	return *f
 }
 
@@ -105,6 +116,7 @@ func NullableFloat64(f *float64) float64 {
 	if f == nil {
 		return 0.0
 	}
+
 	return *f
 }
 
@@ -114,6 +126,7 @@ func NullableComplex64(c *complex64) complex64 {
 	if c == nil {
 		return 0 + 0i
 	}
+
 	return *c
 }
 
@@ -123,5 +136,6 @@ func NullableComplex128(c *complex128) complex128 {
 	if c == nil {
 		return 0 + 0i
 	}
+
 	return *c
 }

--- a/pointers/text.go
+++ b/pointers/text.go
@@ -6,6 +6,7 @@ func NullableString(s *string) string {
 	if s == nil {
 		return ""
 	}
+
 	return *s
 }
 
@@ -15,5 +16,6 @@ func NullableByteSlice(b *[]byte) []byte {
 	if b == nil {
 		return []byte{}
 	}
+
 	return *b
 }

--- a/pointers/text_test.go
+++ b/pointers/text_test.go
@@ -73,6 +73,7 @@ func TestNullableByteSlice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NullableByteSlice(tt.args.b)
 			if len(got) == 0 && len(tt.want) == 0 {
+
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/rand/rand.go
+++ b/rand/rand.go
@@ -21,6 +21,7 @@ func Number() (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to generate random number: %w", err)
 	}
+
 	return n.Int64(), nil
 }
 
@@ -90,6 +91,7 @@ func Shuffle[T any](slice []T) error {
 		}
 		slice[i], slice[int(j)] = slice[int(j)], slice[i]
 	}
+
 	return nil
 }
 

--- a/rand/rand_test.go
+++ b/rand/rand_test.go
@@ -15,6 +15,7 @@ func TestNumber(t *testing.T) {
 		n, err := Number()
 		if err != nil {
 			t.Errorf("Number() error = %v", err)
+
 			return
 		}
 
@@ -62,6 +63,7 @@ func TestNumberInRange(t *testing.T) {
 			got, err := NumberInRange(tt.min, tt.max)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NumberInRange() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 
@@ -78,12 +80,14 @@ func TestString(t *testing.T) {
 	s1, err := String()
 	if err != nil {
 		t.Errorf("String() error = %v", err)
+
 		return
 	}
 
 	s2, err := String()
 	if err != nil {
 		t.Errorf("String() error = %v", err)
+
 		return
 	}
 
@@ -128,6 +132,7 @@ func TestStringWithLength(t *testing.T) {
 			got, err := StringWithLength(tt.length)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StringWithLength() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 
@@ -161,6 +166,7 @@ func TestPick(t *testing.T) {
 			got, err := Pick(tt.slice)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Pick() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 
@@ -202,6 +208,7 @@ func TestShuffle(t *testing.T) {
 			err := Shuffle(tt.slice)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Shuffle() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 
@@ -209,6 +216,7 @@ func TestShuffle(t *testing.T) {
 				// Check length hasn't changed
 				if len(tt.slice) != len(original) {
 					t.Errorf("Shuffle() changed slice length")
+
 					return
 				}
 
@@ -220,6 +228,7 @@ func TestShuffle(t *testing.T) {
 				for _, v := range original {
 					if !seen[v] {
 						t.Errorf("Shuffle() lost element %v", v)
+
 						return
 					}
 				}
@@ -264,6 +273,7 @@ func TestStringWithCharset(t *testing.T) {
 			got, err := StringWithCharset(tt.length, tt.charset)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StringWithCharset() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 
@@ -290,6 +300,7 @@ func contains[T comparable](slice []T, item T) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -71,6 +71,7 @@ func generateStrings(n int) []string {
 		}
 		data[i] = strBuilder.String()
 	}
+
 	return data
 }
 
@@ -81,6 +82,7 @@ func generateRandomInts(n int) []int {
 	for i := 0; i < n; i++ {
 		data[i] = r.Intn(1000)
 	}
+
 	return data
 }
 

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -108,6 +108,7 @@ func Rot13Encode(input string) string {
 			encoded[i] = char
 		}
 	}
+
 	return string(encoded)
 }
 
@@ -131,6 +132,7 @@ func CaesarEncrypt(input string, shift int) string {
 
 		shifted[i] = shiftedChar
 	}
+
 	return string(shifted)
 }
 
@@ -249,6 +251,7 @@ func Reverse(input string) string {
 	for index, character := range runes {
 		result[lastCharacterIndex-index] = character
 	}
+
 	return string(result)
 }
 
@@ -284,6 +287,7 @@ func CommonPrefix(input ...string) string {
 		for j := 0; j < shortestTextLength; j++ {
 			if prefix[j] != item[j] {
 				prefix = prefix[:j]
+
 				break
 			}
 		}
@@ -331,6 +335,7 @@ func CommonSuffix(input ...string) string {
 		for j, k := suffixLength-1, itemLength-1; j >= 0 && k >= 0; j, k = j-1, k-1 {
 			if suffix[j] != item[k] {
 				suffix = suffix[j+1:]
+
 				break
 			}
 		}

--- a/structs/structs_test.go
+++ b/structs/structs_test.go
@@ -85,6 +85,7 @@ func TestCompareStructs(t *testing.T) {
 			got, err := CompareStructs(tt.old, tt.new)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CompareStructs() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/templates/html_test.go
+++ b/templates/html_test.go
@@ -189,6 +189,7 @@ func TestRenderHTML(t *testing.T) {
 			err = tmpl.Execute(&sb, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			got := sb.String()

--- a/templates/text_test.go
+++ b/templates/text_test.go
@@ -162,6 +162,7 @@ func TestRenderText(t *testing.T) {
 			got, err := RenderText(tt.args.tmpl, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RenderText() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if got != tt.want {

--- a/time/time.go
+++ b/time/time.go
@@ -40,11 +40,13 @@ func TimeDifferenceHumanReadable(from, to time.Time) string {
 		if diff.Hours() > 24 {
 			return fmt.Sprintf("%d day(s) ago", int(diff.Hours()/24))
 		}
+
 		return fmt.Sprintf("in %d hour(s)", int(diff.Hours()))
 	}
 	if diff.Hours() > 24 {
 		return fmt.Sprintf("in %d day(s)", int(diff.Hours()/24))
 	}
+
 	return fmt.Sprintf("in %d hour(s)", int(diff.Hours()))
 }
 
@@ -58,6 +60,7 @@ func DurationUntilNext(day time.Weekday, t time.Time) time.Duration {
 	}
 
 	next := t.AddDate(0, 0, daysAhead)
+
 	return next.Sub(t)
 }
 
@@ -102,12 +105,14 @@ func NextOccurrence(hour, minute, second int, t time.Time) time.Time {
 	if !next.After(t) {
 		next = next.Add(24 * time.Hour)
 	}
+
 	return next
 }
 
 // WeekNumber returns the year and week number for the given time
 func WeekNumber(t time.Time) (int, int) {
 	year, week := t.ISOWeek()
+
 	return year, week
 }
 
@@ -115,6 +120,7 @@ func WeekNumber(t time.Time) (int, int) {
 func DaysBetween(start, end time.Time) int {
 	start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
 	end = time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, end.Location())
+
 	return int(end.Sub(start).Hours() / 24)
 }
 
@@ -134,6 +140,7 @@ func SplitDuration(d time.Duration) (days, hours, minutes, seconds int) {
 	hours = int(d.Hours()) % 24
 	minutes = int(d.Minutes()) % 60
 	seconds = int(d.Seconds()) % 60
+
 	return
 }
 
@@ -187,5 +194,6 @@ func FormatForDisplay(t time.Time) string {
 
 func IsToday(t time.Time) bool {
 	now := time.Now()
+
 	return t.Year() == now.Year() && t.YearDay() == now.YearDay()
 }

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -366,6 +366,7 @@ func TestConvertToTimeZone(t *testing.T) {
 			got, err := ConvertToTimeZone(tt.args.t, tt.args.location)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ConvertToTimeZone() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if !tt.wantErr && !got.Equal(tt.want) {
@@ -483,6 +484,7 @@ func TestCalculateAge(t *testing.T) {
 				if now.Before(time.Date(now.Year(), 2, 29, 0, 0, 0, 0, time.UTC)) {
 					leapYearAge--
 				}
+
 				return leapYearAge
 			}(),
 		},
@@ -1022,6 +1024,7 @@ func TestGetMonthName(t *testing.T) {
 			got, err := GetMonthName(tt.args.monthNumber)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetMonthName() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if got != tt.want {
@@ -1087,6 +1090,7 @@ func TestGetDayName(t *testing.T) {
 			got, err := GetDayName(tt.args.dayNumber)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDayName() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if got != tt.want {

--- a/url/url.go
+++ b/url/url.go
@@ -182,6 +182,7 @@ func AddQueryParams(urlStr string, params map[string]string) (string, error) {
 		queryParams.Add(key, value)
 	}
 	parsedURL.RawQuery = queryParams.Encode()
+
 	return parsedURL.String(), nil
 }
 
@@ -252,6 +253,7 @@ func IsValidURL(urlStr string, allowedReqSchemes []string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 


### PR DESCRIPTION
Closes #104

### Description:
I enabled the nlreturn linter and cleaned up all the code that needed formatting.
Some parts of the code were marked as wrong by the linter, anyhow, for how it is structured, I don't think it should be changed. 
An example of this code is the following:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/76051dfc-7553-4b21-8d98-7d37e098a64e" />

Tell me if I should change the format of all this anonymous functions as well, they're mainly in the test file, just to let you understand what I'm talking about

### Checklist:  
- [x] **Tests Passing**: Verify by running `make test`.  
- [] **Golint Passing**: Confirm by running `make lint`.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced improved URL query parameter validation to ensure reliable input processing.

- **Bug Fixes**
	- Enhanced error handling and control flow across various operations including caching, timing, and random value generation.
	- Improved consistency and clarity in algorithms handling numerical, boolean, and string operations.

- **Refactor & Style**
	- Streamlined return paths and refined code formatting to boost readability and robustness.
	- Upgraded test routines with early error exits for more dependable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->