### PR TITLE
feat: add Truncate function with options, example, and unit tests

### DIFF
--- a/strings/EXAMPLES.md
+++ b/strings/EXAMPLES.md
@@ -146,4 +146,16 @@ func main() {
 }
 ```
 
+### Truncate
+
+```go
+func main() {
+	short := Truncate("This is a long string that needs to be truncated", &TruncateOptions{Length: 20, Omission: "°°°"})
+	fmt.Println(short) // Output: This is a long strin°°°
+
+	defaultShort := Truncate("Short example", nil)
+fmt.Println(defaultShort) // Output: Short examp...
+}
+```
+
 ---

--- a/strings/README.md
+++ b/strings/README.md
@@ -15,6 +15,7 @@
 - **CommonSuffix**: Finds the longest common suffix of a set of strings.
 - **RunLengthEncode** Encodes a string using Run-length-encoding.
 - **RunLengthDecode** Decodes a string that has been encoded using Run-length-encoding. Ruturns the original string and an error if the encoding failed
+- **Truncate** Shortens a string to a maximum length and appends an omission suffix if truncated.
 
 ## Examples:
 

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -360,6 +360,10 @@ func Truncate(input string, opts *TruncateOptions) string {
 	length := 12
 	omission := "..."
 
+	if len(input) <= length {
+		return input
+	}
+
 	if opts != nil {
 		if opts.Length > 0 {
 			length = opts.Length
@@ -367,10 +371,6 @@ func Truncate(input string, opts *TruncateOptions) string {
 		if opts.Omission != "" {
 			omission = opts.Omission
 		}
-	}
-
-	if len(input) <= length {
-		return input
 	}
 
 	return input[:length] + omission

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -20,6 +20,12 @@ type SubstringSearchOptions struct {
 	ReturnIndexes   bool // Return the starting indexes of found substrings
 }
 
+// TruncateOptions represents optional parameters for the Truncate function.
+type TruncateOptions struct {
+	Length   int
+	Omission string
+}
+
 // SubstringSearch performs substring search in a string and optionally returns indexes.
 func SubstringSearch(input, substring string, options SubstringSearchOptions) []string {
 	var result []string
@@ -342,4 +348,30 @@ func CommonSuffix(input ...string) string {
 	}
 
 	return string(suffix)
+}
+
+// Truncate shortens a given input string based on provided options.
+// Parameters:
+// - input: the original string to truncate.
+// - opts: optional settings to specify truncation length and omission suffix.
+// If opts is nil or certain fields are unspecified, defaults are applied:
+// Length defaults to 12 and Omission defaults to "...".
+func Truncate(input string, opts *TruncateOptions) string {
+	length := 12
+	omission := "..."
+
+	if opts != nil {
+		if opts.Length > 0 {
+			length = opts.Length
+		}
+		if opts.Omission != "" {
+			omission = opts.Omission
+		}
+	}
+
+	if len(input) <= length {
+		return input
+	}
+
+	return input[:length] + omission
 }

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -376,7 +376,7 @@ func Truncate(input string, opts *TruncateOptions) string {
 	// Consider omission length in the final string length
 	effectiveLength := length - len(omission)
 	if effectiveLength <= 0 {
-		effectiveLength = 1  // Ensure at least one character from input if possible
+		effectiveLength = 1 // Ensure at least one character from input if possible
 	}
 
 	return input[:effectiveLength] + omission

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -373,5 +373,10 @@ func Truncate(input string, opts *TruncateOptions) string {
 		}
 	}
 
-	return input[:length] + omission
+	// Consider omission length in the final string length
+	effectiveLength := length - len(omission)
+	if effectiveLength <= 0 {
+		effectiveLength = 1  // Ensure at least one character from input if possible
+	}
+	return input[:effectiveLength] + omission
 }

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -360,10 +360,6 @@ func Truncate(input string, opts *TruncateOptions) string {
 	length := 12
 	omission := "..."
 
-	if len(input) <= length {
-		return input
-	}
-
 	if opts != nil {
 		if opts.Length > 0 {
 			length = opts.Length
@@ -373,10 +369,15 @@ func Truncate(input string, opts *TruncateOptions) string {
 		}
 	}
 
+	if len(input) <= length {
+		return input
+	}
+
 	// Consider omission length in the final string length
 	effectiveLength := length - len(omission)
 	if effectiveLength <= 0 {
 		effectiveLength = 1  // Ensure at least one character from input if possible
 	}
+
 	return input[:effectiveLength] + omission
 }

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -583,3 +583,51 @@ func BenchmarkCommonSuffix(b *testing.B) {
 		CommonSuffix("testing", "running", "jumping")
 	}
 }
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		options *TruncateOptions
+		want    string
+	}{
+		{
+			name:    "truncate with default options",
+			input:   "This is a long string",
+			options: nil,
+			want:    "This is a lo...",
+		},
+		{
+			name:    "truncate with custom length and omission",
+			input:   "Hello World from Go",
+			options: &TruncateOptions{Length: 5, Omission: "--"},
+			want:    "Hello--",
+		},
+		{
+			name:    "no truncation needed (short string)",
+			input:   "Short",
+			options: nil,
+			want:    "Short",
+		},
+		{
+			name:    "truncate with custom omission only",
+			input:   "Custom omission example",
+			options: &TruncateOptions{Length: 10, Omission: "[cut]"},
+			want:    "Custom omi[cut]",
+		},
+		{
+			name:    "truncate with length only",
+			input:   "Length only test",
+			options: &TruncateOptions{Length: 6},
+			want:    "Length...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Truncate(tt.input, tt.options); got != tt.want {
+				t.Errorf("Truncate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -595,13 +595,13 @@ func TestTruncate(t *testing.T) {
 			name:    "truncate with default options",
 			input:   "This is a long string",
 			options: nil,
-			want:    "This is a lo...",
+			want:    "This is a...",
 		},
 		{
 			name:    "truncate with custom length and omission",
 			input:   "Hello World from Go",
 			options: &TruncateOptions{Length: 5, Omission: "--"},
-			want:    "Hello--",
+			want:    "Hel--",
 		},
 		{
 			name:    "no truncation needed (short string)",
@@ -613,13 +613,13 @@ func TestTruncate(t *testing.T) {
 			name:    "truncate with custom omission only",
 			input:   "Custom omission example",
 			options: &TruncateOptions{Length: 10, Omission: "[cut]"},
-			want:    "Custom omi[cut]",
+			want:    "Custo[cut]",
 		},
 		{
 			name:    "truncate with length only",
 			input:   "Length only test",
 			options: &TruncateOptions{Length: 6},
-			want:    "Length...",
+			want:    "Len...",
 		},
 	}
 


### PR DESCRIPTION
### Description:
Add Truncate function with options, example, and unit tests.

### Checklist:  
- [ ] **Tests Passing**: Verify by running `make test`.  
- [ ] **Golint Passing**: Confirm by running `make lint`.  

#### If added a new utility function or updated existing function logic:
* [ ] Updated the utility package `EXAMPLES.md`
* [ ] Updated the utility package `README.md`

#### If added a new utility package:
* [ ] Updated the main `README.md` utility packages table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a string truncation capability that shortens text to a specified length and appends a customizable omission when needed.
- **Documentation**
	- Added new examples and updated usage instructions for the `Truncate` function in the documentation.
- **Tests**
	- Added comprehensive tests covering various truncation scenarios to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->