### PR TITLE
golangci-lint: Updated config to V2, with V1 fallback

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.22
+          go-version: '1.23.3'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.60
+          version: v2.3.1

--- a/.golangci.v1.yml
+++ b/.golangci.v1.yml
@@ -1,0 +1,19 @@
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - goimports
+    - gofmt
+    - nlreturn
+    - gosec
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+          - nlreturn

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,34 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - govet
-    - staticcheck
     - errcheck
-    - goimports
-    - gofmt
-    - nlreturn
     - gosec
-issues:
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
+    - govet
+    - nlreturn
+    - staticcheck
+  exclusions:
+    generated: strict
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
           - nlreturn
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: strict
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 # Run golangci-lint
 lint:
 	@command -v golangci-lint > /dev/null || (echo "Error: golangci-lint is not installed" && exit 1)
-	@version=$$(golangci-lint version | grep -oE 'version [0-9]+\.[0-9]+\.[0-9]+' | awk '{print $$2}'); \
+	@version=$$(golangci-lint version | grep -oE 'version v?[0-9]+\.[0-9]+\.[0-9]+' | awk '{print $$2}' | sed 's/^v//'); \
 	config=".golangci.yml"; \
 	if echo "$$version" | grep -q '^1\.'; then \
     		config=".golangci.v1.yml"; \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 test:
 	bash ./scripts/test.sh
 
+# Run golangci-lint
 lint:
-	@which golangci-lint > /dev/null || (echo "Error: golangci-lint is not installed" && exit 1)
-	golangci-lint run --config=.golangci.yml
+	@command -v golangci-lint > /dev/null || (echo "Error: golangci-lint is not installed" && exit 1)
+	@version=$$(golangci-lint version | grep -oE 'version [0-9]+\.[0-9]+\.[0-9]+' | awk '{print $$2}'); \
+	config=".golangci.yml"; \
+	if echo "$$version" | grep -q '^1\.'; then \
+    		config=".golangci.v1.yml"; \
+	fi; \
+	golangci-lint run --config=$$config


### PR DESCRIPTION
### Description:
Updated golangci-lint config to Version 2, and added the V1 config as fallback.
Also, updated Makefile, to ensure that the correct config file is used, depending on the version of golangci-lint installed.

### Checklist:  
- [x] **Tests Passing**: Verify by running `make test`.  
- [x] **Golint Passing**: Confirm by running `make lint`.  

#### If added a new utility function or updated existing function logic:
* [ ] Updated the utility package `EXAMPLES.md`
* [ ] Updated the utility package `README.md`

#### If added a new utility package:
* [ ] Updated the main `README.md` utility packages table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to support both version 1.x and 2.x of the linting tool, ensuring compatibility and improved control over which checks and formatters are run.
  * Enhanced the linting process in the build script to automatically select the appropriate configuration file based on the installed tool version.
  * Upgraded GitHub Actions workflow to use newer Go and golangci-lint versions for improved linting environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->