### PR TITLE
Update Go to v1.24 + Cleanup

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23.3'
+        go-version-file: 'go.mod'
         cache: true
 
     - name: Verify dependencies

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.3'
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A common utilities library for Go.
 
 ## Prerequisites
 
-- **Go**: The project is written in Golang. Ensure you have Go installed (preferably Go 1.23.3 or later). You can download it [here](https://go.dev/doc/install).
+- **Go**: The project is written in Golang. Ensure you have Go installed (preferably Go 1.24 or later). You can download it [here](https://go.dev/doc/install).
 - **Git**: Required for cloning the repository.
 
 ## Installation

--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -99,10 +99,12 @@ func TestSafeCacheWrapperConcurrency(t *testing.T) {
 	cachedSquare := SafeCacheWrapper(square)
 	var wg sync.WaitGroup
 
+	const routines = 10
+
 	// Test concurrency with multiple goroutines.
-	results := make([]int, 10)
-	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	results := make([]int, routines)
+	wg.Add(routines)
+	for i := range routines {
 		go func(idx int) {
 			defer wg.Done()
 			results[idx] = cachedSquare(4) // All goroutines calculate square of 4.
@@ -162,7 +164,7 @@ func BenchmarkSafeCachedFib(b *testing.B) {
 
 func BenchmarkConcurrentSafeCachedFib(b *testing.B) {
 	cachedFib := SafeCacheWrapper(fib)
-	_ = cachedFib(30) // warp-up the cache before running the benchmark
+	_ = cachedFib(30) // warm-up the cache before running the benchmark
 
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {

--- a/caching/caching_test.go
+++ b/caching/caching_test.go
@@ -136,37 +136,35 @@ func fib(n int) int {
 
 func BenchmarkFib(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = fib(30)
 	}
 }
 
 func BenchmarkCachedFib(b *testing.B) {
 	cachedFib := CacheWrapper(fib)
-
+	_ = cachedFib(30) // warm-up the cache before running the benchmark
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = cachedFib(30)
 	}
 }
 
 func BenchmarkSafeCachedFib(b *testing.B) {
 	cachedFib := SafeCacheWrapper(fib)
+	_ = cachedFib(30) // warm-up the cache before running the benchmark
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = cachedFib(30)
 	}
 }
 
 func BenchmarkConcurrentSafeCachedFib(b *testing.B) {
 	cachedFib := SafeCacheWrapper(fib)
+	_ = cachedFib(30) // warp-up the cache before running the benchmark
 
 	b.ReportAllocs()
-	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			_ = cachedFib(30)

--- a/conversion/conversion.go
+++ b/conversion/conversion.go
@@ -56,7 +56,7 @@ func SecondsToMinutes(s int64) float64 {
 // MinutesToSeconds converts minutes to seconds.
 // It takes an integer value of minutes and returns the equivalent in seconds as an int64.
 func MinutesToSeconds(m int64) int64 {
-	return int64(m * 60)
+	return m * 60
 }
 
 // MinutesToHours converts minutes to hours.
@@ -68,7 +68,7 @@ func MinutesToHours(m int64) float64 {
 // HoursToMinutes converts hours to minutes.
 // It takes an integer value of hours and returns the equivalent in minutes as an int64.
 func HoursToMinutes(h int64) int64 {
-	return int64(h * 60)
+	return h * 60
 }
 
 // HoursToDays converts hours to days.
@@ -80,7 +80,7 @@ func HoursToDays(h int64) float64 {
 // DaysToHours converts days to hours.
 // It takes an integer value of days and returns the equivalent in days as an int64.
 func DaysToHours(d int64) int64 {
-	return int64(d * 24)
+	return d * 24
 }
 
 // Temperature conversion functions

--- a/ctxutils/ctxutils_test.go
+++ b/ctxutils/ctxutils_test.go
@@ -77,13 +77,10 @@ func TestSetIntValueWithWrongKey(t *testing.T) {
 
 func BenchmarkSettingAndGettingStringKey(b *testing.B) {
 	ctx := context.Background()
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
 	key := ContextKeyString{Key: "id"}
 
-	for i := 0; i < b.N; i++ {
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
 		ctx = SetStringValue(ctx, key, fmt.Sprintf("value-%d", i))
 		_, _ = GetStringValue(ctx, key)
 	}
@@ -91,13 +88,10 @@ func BenchmarkSettingAndGettingStringKey(b *testing.B) {
 
 func BenchmarkSettingAndGettingIntKey(b *testing.B) {
 	ctx := context.Background()
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
 	key := ContextKeyInt{Key: 0}
 
-	for i := 0; i < b.N; i++ {
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
 		ctx = SetIntValue(ctx, key, i)
 		_, _ = GetIntValue(ctx, key)
 	}

--- a/ctxutils/ctxutils_test.go
+++ b/ctxutils/ctxutils_test.go
@@ -2,7 +2,6 @@ package ctxutils
 
 import (
 	"context"
-	"fmt"
 	"testing"
 )
 
@@ -76,23 +75,31 @@ func TestSetIntValueWithWrongKey(t *testing.T) {
 // ================================================================================
 
 func BenchmarkSettingAndGettingStringKey(b *testing.B) {
-	ctx := context.Background()
-	key := ContextKeyString{Key: "id"}
+	var (
+		ctx   context.Context
+		key   = ContextKeyString{Key: "id"}
+		value = "value-123"
+	)
 
 	b.ReportAllocs()
-	for i := 0; b.Loop(); i++ {
-		ctx = SetStringValue(ctx, key, fmt.Sprintf("value-%d", i))
+	for b.Loop() {
+		ctx = context.Background()
+		ctx = SetStringValue(ctx, key, value)
 		_, _ = GetStringValue(ctx, key)
 	}
 }
 
 func BenchmarkSettingAndGettingIntKey(b *testing.B) {
-	ctx := context.Background()
-	key := ContextKeyInt{Key: 0}
+	var (
+		ctx   context.Context
+		key   = ContextKeyInt{Key: 0}
+		value = 123
+	)
 
 	b.ReportAllocs()
-	for i := 0; b.Loop(); i++ {
-		ctx = SetIntValue(ctx, key, i)
+	for b.Loop() {
+		ctx = context.Background()
+		ctx = SetIntValue(ctx, key, value)
 		_, _ = GetIntValue(ctx, key)
 	}
 }

--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -81,25 +81,25 @@ func TestRandomAddress(t *testing.T) {
 // ================================================================================
 
 func BenchmarkGenerateUUID(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = RandomUUID()
 	}
 }
 
 func BenchmarkRandomDate(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = RandomDate()
 	}
 }
 
 func BenchmarkRandomPhoneNumber(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = RandomPhoneNumber()
 	}
 }
 
 func BenchmarkRandomAddress(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = RandomAddress()
 	}
 }

--- a/fake/fake_test.go
+++ b/fake/fake_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGenerateUUID(t *testing.T) {
 	uuidSet := make(map[string]struct{})
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		t.Run(fmt.Sprintf("UUIDTest-%d", i), func(t *testing.T) {
 			uuid, err := RandomUUID()
 			if err != nil {

--- a/fsutils/fsutils.go
+++ b/fsutils/fsutils.go
@@ -16,9 +16,9 @@ type ByteSize int64
 
 const (
 	KB ByteSize = 1024
-	MB ByteSize = KB * 1024
-	GB ByteSize = MB * 1024
-	TB ByteSize = GB * 1024
+	MB          = KB * 1024
+	GB          = MB * 1024
+	TB          = GB * 1024
 )
 
 // FormatFileSize formats a file size given in bytes into a human-readable string
@@ -117,13 +117,13 @@ func FilesIdentical(file1, file2 string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f1.Close()
+	defer func() { _ = f1.Close() }()
 
 	f2, err := os.Open(file2)
 	if err != nil {
 		return false, err
 	}
-	defer f2.Close()
+	defer func() { _ = f2.Close() }()
 
 	const chunkSize = 32 * 1024
 	b1 := make([]byte, chunkSize)

--- a/fsutils/fsutils_test.go
+++ b/fsutils/fsutils_test.go
@@ -52,7 +52,7 @@ func TestFindFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Create some test files
 	files := []struct {
@@ -137,7 +137,7 @@ func TestFindFiles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer os.RemoveAll(tempDir)
+		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		if err := os.Chmod(tempDir, 0000); err != nil {
 			t.Fatal(err)
@@ -163,7 +163,7 @@ func TestGetDirectorySize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Create some test files with known sizes
 	files := []struct {
@@ -205,7 +205,7 @@ func TestFilesIdentical(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Create some test files
 	files := []struct {
@@ -254,13 +254,13 @@ func TestDirsIdentical(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir1)
+	defer func() { _ = os.RemoveAll(tempDir1) }()
 
 	tempDir2, err := os.MkdirTemp("", "testdir2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir2)
+	defer func() { _ = os.RemoveAll(tempDir2) }()
 
 	// Create some test files in both directories
 	files1 := []struct {
@@ -340,8 +340,10 @@ func TestDirsIdentical(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		defer os.RemoveAll(dir1)
-		defer os.RemoveAll(dir2)
+		defer func() {
+			_ = os.RemoveAll(dir2)
+			_ = os.RemoveAll(dir1)
+		}()
 
 		identical, err := DirsIdentical(dir1, dir2)
 		if err != nil {
@@ -360,19 +362,19 @@ func setupNestedDirs() (string, string, error) {
 	}
 	defer func() {
 		if err != nil {
-			os.RemoveAll(tempDir1)
+			_ = os.RemoveAll(tempDir1)
 		}
 	}()
 
 	tempDir2, err := os.MkdirTemp("", "nestedtestdir2_")
 	if err != nil {
-		os.RemoveAll(tempDir1)
+		_ = os.RemoveAll(tempDir1)
 
 		return "", "", fmt.Errorf("failed to create tempDir2: %w", err)
 	}
 	defer func() {
 		if err != nil {
-			os.RemoveAll(tempDir2)
+			_ = os.RemoveAll(tempDir2)
 		}
 	}()
 
@@ -403,7 +405,7 @@ func TestGetFileMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Create a test file
 	filePath := filepath.Join(tempDir, "testfile.txt")
@@ -477,7 +479,7 @@ func TestGetFileMetadata(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer os.RemoveAll(tempDir)
+		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		// Create a file and a symlink to it
 		filePath := filepath.Join(tempDir, "testfile.txt")
@@ -506,7 +508,7 @@ func TestFindFilesWithFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Create test files with different sizes and mod times
 	testFiles := []struct {
@@ -606,7 +608,7 @@ func BenchmarkFindFiles(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	for i := 0; i < 100; i++ {
 		filePath := filepath.Join(tempDir, fmt.Sprintf("%d.txt", i))
@@ -627,9 +629,9 @@ func BenchmarkGetDirectorySize(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		filePath := filepath.Join(tempDir, fmt.Sprintf("%d.txt", i))
 		data := make([]byte, 1024) // 1 KB per file
 		if _, err := rand.Read(data); err != nil {
@@ -651,7 +653,7 @@ func BenchmarkFilesIdentical(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	file1 := filepath.Join(tempDir, "file1.txt")
 	file2 := filepath.Join(tempDir, "file2.txt")
@@ -693,7 +695,7 @@ func BenchmarkGetFileMetadata(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	filePath := filepath.Join(tempDir, "testfile.txt")
 	if err := os.WriteFile(filePath, []byte("test"), 0600); err != nil {
@@ -712,7 +714,7 @@ func BenchmarkFindFilesWithFilter(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Create a mix of files: .log, .txt, .md, some large, some small
 	for i := 0; i < 100; i++ {

--- a/fsutils/fsutils_test.go
+++ b/fsutils/fsutils_test.go
@@ -598,8 +598,10 @@ func TestFindFilesWithFilter(t *testing.T) {
 
 func BenchmarkFormatFileSize(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; b.Loop(); i++ {
-		_ = FormatFileSize(int64(i))
+
+	const fileSize = 134217728
+	for b.Loop() {
+		_ = FormatFileSize(fileSize)
 	}
 }
 
@@ -610,7 +612,7 @@ func BenchmarkFindFiles(b *testing.B) {
 	}
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		filePath := filepath.Join(tempDir, fmt.Sprintf("%d.txt", i))
 		if err := os.WriteFile(filePath, []byte{}, 0600); err != nil {
 			b.Fatal(err)
@@ -717,7 +719,7 @@ func BenchmarkFindFilesWithFilter(b *testing.B) {
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Create a mix of files: .log, .txt, .md, some large, some small
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		ext := ".txt"
 		if i%3 == 0 {
 			ext = ".log"

--- a/fsutils/fsutils_test.go
+++ b/fsutils/fsutils_test.go
@@ -596,7 +596,7 @@ func TestFindFilesWithFilter(t *testing.T) {
 
 func BenchmarkFormatFileSize(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		_ = FormatFileSize(int64(i))
 	}
 }
@@ -616,9 +616,8 @@ func BenchmarkFindFiles(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = FindFiles(tempDir, ".txt")
 	}
 }
@@ -641,9 +640,8 @@ func BenchmarkGetDirectorySize(b *testing.B) {
 		}
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetDirectorySize(tempDir)
 	}
 }
@@ -671,9 +669,8 @@ func BenchmarkFilesIdentical(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = FilesIdentical(file1, file2)
 	}
 }
@@ -685,9 +682,8 @@ func BenchmarkDirsIdentical(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = DirsIdentical(dir1, dir2)
 	}
 }
@@ -705,9 +701,8 @@ func BenchmarkGetFileMetadata(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = GetFileMetadata(filePath)
 	}
 }
@@ -743,9 +738,8 @@ func BenchmarkFindFilesWithFilter(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = FindFilesWithFilter(tempDir, func(info os.FileInfo) bool {
 			return !info.IsDir() && info.Size() > 1024 && filepath.Ext(info.Name()) == ".log"
 		})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kashifkhan0771/utils
 
-go 1.23.3
+go 1.24
+
+toolchain go1.24.6
 
 require (
 	github.com/forPelevin/gomoji v1.3.1

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -107,7 +107,7 @@ func (l *Logger) log(level LogLevel, message string) {
 	// Write the log message to the configured output
 	_, err := fmt.Fprint(l.output, logMessage)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to write log: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to write log: %v\n", err)
 	}
 }
 

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -103,8 +103,7 @@ func TestLogger(t *testing.T) {
 func BenchmarkLogger(b *testing.B) {
 	logger := logging.NewLogger("Test", logging.INFO, nil)
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		logger.Info("This is an info message")
 	}
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -2,6 +2,7 @@ package logging_test
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 
@@ -101,7 +102,7 @@ func TestLogger(t *testing.T) {
 // ================================================================================
 
 func BenchmarkLogger(b *testing.B) {
-	logger := logging.NewLogger("Test", logging.INFO, nil)
+	logger := logging.NewLogger("Test", logging.INFO, io.Discard)
 	b.ReportAllocs()
 	for b.Loop() {
 		logger.Info("This is an info message")

--- a/math/math.go
+++ b/math/math.go
@@ -173,7 +173,7 @@ func Sqrt[T number](x T) (float64, error) {
 
 	for {
 		nextZ := z - (z*z-float64(x))/(2*z)
-		if float64(Abs(nextZ-z)) < epsilon {
+		if Abs[float64](nextZ-z) < epsilon {
 			return z, nil
 		}
 		z = nextZ

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -37,6 +37,7 @@ func TestAbsForInts(t *testing.T) {
 		})
 	}
 }
+
 func TestAbsForFloats(t *testing.T) {
 	type args struct {
 		x float32
@@ -756,44 +757,53 @@ func TestIsPrime(t *testing.T) {
 func BenchmarkIntPow(b *testing.B) {
 	b.ReportAllocs()
 
-	bases := []int{2, 3, 4, 5}
-	exponents := []int{2, 3, 4}
-
-	for i := 0; b.Loop(); i++ {
-		base := bases[i%len(bases)]
-		exp := exponents[i%len(exponents)]
-		IntPow(base, exp)
+	const base, exp = 3, 2
+	for b.Loop() {
+		_ = IntPow(base, exp)
 	}
 }
 
 func BenchmarkFactorial(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; b.Loop(); i++ {
-		_, _ = Factorial(i % 20) // Factorial of numbers 0 to 19
+	const x = 7
+	for b.Loop() {
+		_, _ = Factorial(x)
 	}
 }
 
 func BenchmarkGCD(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; b.Loop(); i++ {
-		GCD(i, i+1)
+	const x, y = 17, 19
+	for b.Loop() {
+		_ = GCD(x, y)
 	}
 }
 
 func BenchmarkLCM(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; b.Loop(); i++ {
-		LCM(i, i+1)
+	const x, y = 4, 6
+	for b.Loop() {
+		_ = LCM(x, y)
 	}
 }
 
 func BenchmarkSqrt(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; b.Loop(); i++ {
-		_, _ = Sqrt(i)
+	const pi = 3.14159265358979323846264338327950288419716939937510582097494459230781640628
+	for b.Loop() {
+		_, _ = Sqrt(pi)
+	}
+}
+
+func BenchmarkIsPrime(b *testing.B) {
+	b.ReportAllocs()
+
+	const prime = 2147483647
+	for b.Loop() {
+		_ = IsPrime(prime)
 	}
 }

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -1,6 +1,7 @@
 package math
 
 import (
+	"math"
 	"testing"
 )
 
@@ -27,6 +28,11 @@ func TestAbsForInts(t *testing.T) {
 			name: "success - zero input",
 			args: args{x: 0},
 			want: 0,
+		},
+		{
+			name: "success - negative zero input",
+			args: args{x: -0},
+			want: 0.0,
 		},
 	}
 	for _, tt := range tests {
@@ -69,6 +75,13 @@ func TestAbsForFloats(t *testing.T) {
 				t.Errorf("Abs() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAbsForFloats_NaN(t *testing.T) {
+	got := Abs(float32(math.NaN()))
+	if !math.IsNaN(float64(got)) {
+		t.Errorf("Abs(NaN) = %v, want NaN", got)
 	}
 }
 
@@ -673,8 +686,8 @@ func TestSqrtForFloats(t *testing.T) {
 	}{
 		{
 			name: "success - square root of pi",
-			args: args{x: 3.14159265358979323846264338327950288419716939937510582097494459230781640628},
-			want: 1.77245385090551602729816748334114518279754945612238712821380778985291128458,
+			args: args{x: math.Pi},
+			want: math.SqrtPi,
 		},
 		{
 			name: "success - square root of square root of 2",
@@ -793,9 +806,8 @@ func BenchmarkLCM(b *testing.B) {
 func BenchmarkSqrt(b *testing.B) {
 	b.ReportAllocs()
 
-	const pi = 3.14159265358979323846264338327950288419716939937510582097494459230781640628
 	for b.Loop() {
-		_, _ = Sqrt(pi)
+		_, _ = Sqrt(math.Pi)
 	}
 }
 

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -755,12 +755,11 @@ func TestIsPrime(t *testing.T) {
 
 func BenchmarkIntPow(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	bases := []int{2, 3, 4, 5}
 	exponents := []int{2, 3, 4}
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		base := bases[i%len(bases)]
 		exp := exponents[i%len(exponents)]
 		IntPow(base, exp)
@@ -770,7 +769,7 @@ func BenchmarkIntPow(b *testing.B) {
 func BenchmarkFactorial(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		_, _ = Factorial(i % 20) // Factorial of numbers 0 to 19
 	}
 }
@@ -778,7 +777,7 @@ func BenchmarkFactorial(b *testing.B) {
 func BenchmarkGCD(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		GCD(i, i+1)
 	}
 }
@@ -786,7 +785,7 @@ func BenchmarkGCD(b *testing.B) {
 func BenchmarkLCM(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		LCM(i, i+1)
 	}
 }
@@ -794,7 +793,7 @@ func BenchmarkLCM(b *testing.B) {
 func BenchmarkSqrt(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		_, _ = Sqrt(i)
 	}
 }

--- a/pointers/numeric_test.go
+++ b/pointers/numeric_test.go
@@ -21,7 +21,7 @@ func TestNullableInt(t *testing.T) {
 		{
 			name: "success - i has a value",
 			args: args{
-				i: func() *int { v := int(42); return &v }(),
+				i: func() *int { v := 42; return &v }(),
 			},
 			want: 42,
 		},
@@ -391,14 +391,14 @@ func TestNullableFloat64(t *testing.T) {
 		{
 			name: "success - f has a value",
 			args: args{
-				f: func() *float64 { v := float64(6.28); return &v }(),
+				f: func() *float64 { v := 6.28; return &v }(),
 			},
 			want: 6.28,
 		},
 		{
 			name: "success - f is zero",
 			args: args{
-				f: func() *float64 { v := float64(0.0); return &v }(),
+				f: func() *float64 { v := 0.0; return &v }(),
 			},
 			want: 0.0,
 		},
@@ -471,14 +471,14 @@ func TestNullableComplex128(t *testing.T) {
 		{
 			name: "success - c is not nil and is 0+0i",
 			args: args{
-				c: func() *complex128 { v := complex128(0 + 0i); return &v }(),
+				c: func() *complex128 { v := 0 + 0i; return &v }(),
 			},
 			want: 0 + 0i,
 		},
 		{
 			name: "success - c is not nil and is 3+4i",
 			args: args{
-				c: func() *complex128 { v := complex128(3 + 4i); return &v }(),
+				c: func() *complex128 { v := 3 + 4i; return &v }(),
 			},
 			want: 3 + 4i,
 		},

--- a/pointers/numeric_test.go
+++ b/pointers/numeric_test.go
@@ -2,33 +2,33 @@ package pointers
 
 import "testing"
 
+// ptr is a helper function that returns a pointer to the value of type T.
+func ptr[T any](v T) *T { return &v }
+
+type testCase[T any] struct {
+	name  string
+	input *T
+	want  T
+}
+
 func TestNullableInt(t *testing.T) {
-	type args struct {
-		i *int
-	}
-	tests := []struct {
-		name string
-		args args
-		want int
-	}{
+	tests := []testCase[int]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *int { v := 42; return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(42),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableInt(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableInt(tt.input); got != tt.want {
 				t.Errorf("NullableInt() = %v, want %v", got, tt.want)
 			}
 		})
@@ -36,32 +36,23 @@ func TestNullableInt(t *testing.T) {
 }
 
 func TestNullableInt8(t *testing.T) {
-	type args struct {
-		i *int8
-	}
-	tests := []struct {
-		name string
-		args args
-		want int8
-	}{
+	tests := []testCase[int8]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *int8 { v := int8(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(int8(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableInt8(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableInt8(tt.input); got != tt.want {
 				t.Errorf("NullableInt8() = %v, want %v", got, tt.want)
 			}
 		})
@@ -69,32 +60,23 @@ func TestNullableInt8(t *testing.T) {
 }
 
 func TestNullableInt16(t *testing.T) {
-	type args struct {
-		i *int16
-	}
-	tests := []struct {
-		name string
-		args args
-		want int16
-	}{
+	tests := []testCase[int16]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *int16 { v := int16(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(int16(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableInt16(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableInt16(tt.input); got != tt.want {
 				t.Errorf("NullableInt16() = %v, want %v", got, tt.want)
 			}
 		})
@@ -102,32 +84,23 @@ func TestNullableInt16(t *testing.T) {
 }
 
 func TestNullableInt32(t *testing.T) {
-	type args struct {
-		i *int32
-	}
-	tests := []struct {
-		name string
-		args args
-		want int32
-	}{
+	tests := []testCase[int32]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *int32 { v := int32(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(int32(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableInt32(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableInt32(tt.input); got != tt.want {
 				t.Errorf("NullableInt32() = %v, want %v", got, tt.want)
 			}
 		})
@@ -135,32 +108,23 @@ func TestNullableInt32(t *testing.T) {
 }
 
 func TestNullableInt64(t *testing.T) {
-	type args struct {
-		i *int64
-	}
-	tests := []struct {
-		name string
-		args args
-		want int64
-	}{
+	tests := []testCase[int64]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *int64 { v := int64(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(int64(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableInt64(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableInt64(tt.input); got != tt.want {
 				t.Errorf("NullableInt64() = %v, want %v", got, tt.want)
 			}
 		})
@@ -168,32 +132,23 @@ func TestNullableInt64(t *testing.T) {
 }
 
 func TestNullableUint(t *testing.T) {
-	type args struct {
-		i *uint
-	}
-	tests := []struct {
-		name string
-		args args
-		want uint
-	}{
+	tests := []testCase[uint]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *uint { v := uint(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(uint(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableUint(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableUint(tt.input); got != tt.want {
 				t.Errorf("NullableUint() = %v, want %v", got, tt.want)
 			}
 		})
@@ -201,32 +156,23 @@ func TestNullableUint(t *testing.T) {
 }
 
 func TestNullableUint8(t *testing.T) {
-	type args struct {
-		i *uint8
-	}
-	tests := []struct {
-		name string
-		args args
-		want uint8
-	}{
+	tests := []testCase[uint8]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *uint8 { v := uint8(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(uint8(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableUint8(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableUint8(tt.input); got != tt.want {
 				t.Errorf("NullableUint8() = %v, want %v", got, tt.want)
 			}
 		})
@@ -234,32 +180,23 @@ func TestNullableUint8(t *testing.T) {
 }
 
 func TestNullableUint16(t *testing.T) {
-	type args struct {
-		i *uint16
-	}
-	tests := []struct {
-		name string
-		args args
-		want uint16
-	}{
+	tests := []testCase[uint16]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *uint16 { v := uint16(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(uint16(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableUint16(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableUint16(tt.input); got != tt.want {
 				t.Errorf("NullableUint16() = %v, want %v", got, tt.want)
 			}
 		})
@@ -267,32 +204,23 @@ func TestNullableUint16(t *testing.T) {
 }
 
 func TestNullableUint32(t *testing.T) {
-	type args struct {
-		i *uint32
-	}
-	tests := []struct {
-		name string
-		args args
-		want uint32
-	}{
+	tests := []testCase[uint32]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *uint32 { v := uint32(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(uint32(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableUint32(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableUint32(tt.input); got != tt.want {
 				t.Errorf("NullableUint32() = %v, want %v", got, tt.want)
 			}
 		})
@@ -300,32 +228,23 @@ func TestNullableUint32(t *testing.T) {
 }
 
 func TestNullableUint64(t *testing.T) {
-	type args struct {
-		i *uint64
-	}
-	tests := []struct {
-		name string
-		args args
-		want uint64
-	}{
+	tests := []testCase[uint64]{
 		{
-			name: "success - i is nil",
-			args: args{
-				i: nil,
-			},
-			want: 0,
+			name:  "success - i is nil",
+			input: nil,
+			want:  0,
 		},
 		{
-			name: "success - i has a value",
-			args: args{
-				i: func() *uint64 { v := uint64(42); return &v }(),
-			},
-			want: 42,
+			name:  "success - i has a value",
+			input: ptr(uint64(42)),
+			want:  42,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableUint64(tt.args.i); got != tt.want {
+			t.Parallel()
+
+			if got := NullableUint64(tt.input); got != tt.want {
 				t.Errorf("NullableUint64() = %v, want %v", got, tt.want)
 			}
 		})
@@ -333,39 +252,28 @@ func TestNullableUint64(t *testing.T) {
 }
 
 func TestNullableFloat32(t *testing.T) {
-	type args struct {
-		f *float32
-	}
-	tests := []struct {
-		name string
-		args args
-		want float32
-	}{
+	tests := []testCase[float32]{
 		{
-			name: "success - f is nil",
-			args: args{
-				f: nil,
-			},
-			want: 0.0,
+			name:  "success - f is nil",
+			input: nil,
+			want:  0.0,
 		},
 		{
-			name: "success - f has a value",
-			args: args{
-				f: func() *float32 { v := float32(3.14); return &v }(),
-			},
-			want: 3.14,
+			name:  "success - f has a value",
+			input: ptr(float32(3.14)),
+			want:  3.14,
 		},
 		{
-			name: "success - f is zero",
-			args: args{
-				f: func() *float32 { v := float32(0.0); return &v }(),
-			},
-			want: 0.0,
+			name:  "success - f is zero",
+			input: ptr(float32(0.0)),
+			want:  0.0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableFloat32(tt.args.f); got != tt.want {
+			t.Parallel()
+
+			if got := NullableFloat32(tt.input); got != tt.want {
 				t.Errorf("NullableFloat32() = %v, want %v", got, tt.want)
 			}
 		})
@@ -373,39 +281,28 @@ func TestNullableFloat32(t *testing.T) {
 }
 
 func TestNullableFloat64(t *testing.T) {
-	type args struct {
-		f *float64
-	}
-	tests := []struct {
-		name string
-		args args
-		want float64
-	}{
+	tests := []testCase[float64]{
 		{
-			name: "success - f is nil",
-			args: args{
-				f: nil,
-			},
-			want: 0.0,
+			name:  "success - f is nil",
+			input: nil,
+			want:  0.0,
 		},
 		{
-			name: "success - f has a value",
-			args: args{
-				f: func() *float64 { v := 6.28; return &v }(),
-			},
-			want: 6.28,
+			name:  "success - f has a value",
+			input: ptr(6.28),
+			want:  6.28,
 		},
 		{
-			name: "success - f is zero",
-			args: args{
-				f: func() *float64 { v := 0.0; return &v }(),
-			},
-			want: 0.0,
+			name:  "success - f is zero",
+			input: ptr(0.0),
+			want:  0.0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableFloat64(tt.args.f); got != tt.want {
+			t.Parallel()
+
+			if got := NullableFloat64(tt.input); got != tt.want {
 				t.Errorf("NullableFloat64() = %v, want %v", got, tt.want)
 			}
 		})
@@ -413,39 +310,28 @@ func TestNullableFloat64(t *testing.T) {
 }
 
 func TestNullableComplex64(t *testing.T) {
-	type args struct {
-		c *complex64
-	}
-	tests := []struct {
-		name string
-		args args
-		want complex64
-	}{
+	tests := []testCase[complex64]{
 		{
-			name: "success - c is nil",
-			args: args{
-				c: nil,
-			},
-			want: 0 + 0i,
+			name:  "success - c is nil",
+			input: nil,
+			want:  0 + 0i,
 		},
 		{
-			name: "success - c is not nil and is 0+0i",
-			args: args{
-				c: func() *complex64 { v := complex64(0 + 0i); return &v }(),
-			},
-			want: 0 + 0i,
+			name:  "success - c is not nil and is 0+0i",
+			input: ptr(complex64(0 + 0i)),
+			want:  0 + 0i,
 		},
 		{
-			name: "success - c is not nil and is 1+2i",
-			args: args{
-				c: func() *complex64 { v := complex64(1 + 2i); return &v }(),
-			},
-			want: 1 + 2i,
+			name:  "success - c is not nil and is 1+2i",
+			input: ptr(complex64(1 + 2i)),
+			want:  1 + 2i,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableComplex64(tt.args.c); got != tt.want {
+			t.Parallel()
+
+			if got := NullableComplex64(tt.input); got != tt.want {
 				t.Errorf("NullableComplex64() = %v, want %v", got, tt.want)
 			}
 		})
@@ -453,39 +339,28 @@ func TestNullableComplex64(t *testing.T) {
 }
 
 func TestNullableComplex128(t *testing.T) {
-	type args struct {
-		c *complex128
-	}
-	tests := []struct {
-		name string
-		args args
-		want complex128
-	}{
+	tests := []testCase[complex128]{
 		{
-			name: "success - c is nil",
-			args: args{
-				c: nil,
-			},
-			want: 0 + 0i,
+			name:  "success - c is nil",
+			input: nil,
+			want:  0 + 0i,
 		},
 		{
-			name: "success - c is not nil and is 0+0i",
-			args: args{
-				c: func() *complex128 { v := 0 + 0i; return &v }(),
-			},
-			want: 0 + 0i,
+			name:  "success - c is not nil and is 0+0i",
+			input: ptr(0 + 0i),
+			want:  0 + 0i,
 		},
 		{
-			name: "success - c is not nil and is 3+4i",
-			args: args{
-				c: func() *complex128 { v := 3 + 4i; return &v }(),
-			},
-			want: 3 + 4i,
+			name:  "success - c is not nil and is 3+4i",
+			input: ptr(3 + 4i),
+			want:  3 + 4i,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NullableComplex128(tt.args.c); got != tt.want {
+			t.Parallel()
+
+			if got := NullableComplex128(tt.input); got != tt.want {
 				t.Errorf("NullableComplex128() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pointers/numeric_test.go
+++ b/pointers/numeric_test.go
@@ -1,6 +1,9 @@
 package pointers
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 // ptr is a helper function that returns a pointer to the value of type T.
 func ptr[T any](v T) *T { return &v }
@@ -260,8 +263,8 @@ func TestNullableFloat32(t *testing.T) {
 		},
 		{
 			name:  "success - f has a value",
-			input: ptr(float32(3.14)),
-			want:  3.14,
+			input: ptr(float32(math.Pi)),
+			want:  math.Pi,
 		},
 		{
 			name:  "success - f is zero",

--- a/rand/rand_test.go
+++ b/rand/rand_test.go
@@ -386,10 +386,12 @@ func BenchmarkStringWithLength(b *testing.B) {
 	}
 }
 
-var benchArray = make([]int, 1000)
+const benchSize = 1000
+
+var benchArray = make([]int, benchSize)
 
 func init() {
-	for i := 0; i < 1000; i++ {
+	for i := range benchSize {
 		benchArray[i] = i
 	}
 }
@@ -406,10 +408,8 @@ func BenchmarkPick(b *testing.B) {
 }
 
 func BenchmarkShuffle(b *testing.B) {
-	array := make([]int, 1000)
-	for i := 0; i < 1000; i++ {
-		array[i] = i
-	}
+	array := make([]int, len(benchArray))
+	copy(array, benchArray)
 
 	b.ReportAllocs()
 

--- a/rand/rand_test.go
+++ b/rand/rand_test.go
@@ -346,42 +346,42 @@ func contains[T comparable](slice []T, item T) bool {
 
 func BenchmarkNumberCrypto(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = SecureNumber()
 	}
 }
 
 func BenchmarkIntMathV2(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Int()
 	}
 }
 
 func BenchmarkInt64MathV2(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Int64()
 	}
 }
 
 func BenchmarkNumberInRange(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = NumberInRange(0, 1000)
 	}
 }
 
 func BenchmarkString(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = String()
 	}
 }
 
 func BenchmarkStringWithLength(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = StringWithLength(100)
 	}
 }
@@ -399,9 +399,8 @@ func BenchmarkPick(b *testing.B) {
 	copy(array, benchArray)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = Pick(array)
 	}
 }
@@ -413,16 +412,15 @@ func BenchmarkShuffle(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Shuffle(array)
 	}
 }
 
 func BenchmarkStringWithCharset(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = StringWithCharset(1000, DefaultCharset)
 	}
 }

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -77,11 +77,11 @@ func generateStrings(n int) []string {
 }
 
 func generateRandomInts(n int) []int {
-	max := big.NewInt(1000)
+	maxVal := big.NewInt(1000)
 	data := make([]int, n)
 
 	for i := 0; i < n; i++ {
-		num, err := rand.Int(rand.Reader, max)
+		num, err := rand.Int(rand.Reader, maxVal)
 		if err != nil {
 			panic(err)
 		}

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -95,9 +95,8 @@ func BenchmarkRemoveDuplicateStrings(b *testing.B) {
 	data := generateStrings(100000)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		RemoveDuplicateStr(data)
 	}
 }
@@ -106,9 +105,8 @@ func BenchmarkRemoveDuplicateInts(b *testing.B) {
 	data := generateRandomInts(100000)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		RemoveDuplicateInt(data)
 	}
 }

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -64,7 +64,7 @@ func generateStrings(n int) []string {
 	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?/~`"
 	data := make([]string, n)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		strLen := (i % 10) + 5 // Generate strings of length 5-14
 		var strBuilder strings.Builder
 		for j := 0; j < strLen; j++ {
@@ -80,7 +80,7 @@ func generateRandomInts(n int) []int {
 	maxVal := big.NewInt(1000)
 	data := make([]int, n)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		num, err := rand.Int(rand.Reader, maxVal)
 		if err != nil {
 			panic(err)

--- a/slugger/slugger.go
+++ b/slugger/slugger.go
@@ -34,8 +34,8 @@ func (slugger *Slugger) Slug(s, separator string) string {
 
 	s = strings.ToLower(s)
 
-	for old, new := range slugger.Substitutions {
-		s = strings.ReplaceAll(s, old, " "+new)
+	for oldValue, newValue := range slugger.Substitutions {
+		s = strings.ReplaceAll(s, oldValue, " "+newValue)
 	}
 
 	safe := normalizeToSafeASCII(s)

--- a/slugger/slugger.go
+++ b/slugger/slugger.go
@@ -1,6 +1,8 @@
 package slugger
 
 import (
+	"maps"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -34,7 +36,9 @@ func (slugger *Slugger) Slug(s, separator string) string {
 
 	s = strings.ToLower(s)
 
-	for oldValue, newValue := range slugger.Substitutions {
+	sortedKeys := slices.Sorted(maps.Keys(slugger.Substitutions))
+	for _, oldValue := range sortedKeys {
+		newValue := slugger.Substitutions[oldValue]
 		s = strings.ReplaceAll(s, oldValue, " "+newValue)
 	}
 
@@ -43,7 +47,7 @@ func (slugger *Slugger) Slug(s, separator string) string {
 	var slugBuilder strings.Builder
 
 	for i := range words {
-		slugBuilder.WriteString(strings.ToLower(strings.TrimSpace(words[i])))
+		slugBuilder.WriteString(strings.ToLower(words[i]))
 
 		if i != len(words)-1 {
 			slugBuilder.WriteString(separator)

--- a/slugger/slugger_test.go
+++ b/slugger/slugger_test.go
@@ -74,7 +74,7 @@ func BenchmarkSlugger_Slug(b *testing.B) {
 		},
 	}
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		slugger.Slug("Wôrķšpáçè ~~sèťtïñğš~~", "")
 	}
 }
@@ -88,7 +88,7 @@ func BenchmarkSlugger_Slug_WithEmoji(b *testing.B) {
 		},
 	}
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		slugger.Slug("a 😺, 🐈‍⬛, and a 🦁 go to 🏞️", "")
 	}
 }
@@ -102,7 +102,7 @@ func BenchmarkSlugger_Slug_CustomSeparator(b *testing.B) {
 		},
 	}
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		slugger.Slug("Wôrķšpáçè ~~sèťtïñğš~~", "|")
 	}
 }

--- a/sort/helper.go
+++ b/sort/helper.go
@@ -119,6 +119,6 @@ func heapify[T number](arr []T, n, i int) {
 	// If largest is not root
 	if largest != i {
 		arr[i], arr[largest] = arr[largest], arr[i] // Swap
-		heapify(arr, n, largest)                    // Recursively heapify the affected sub-tree
+		heapify[T](arr, n, largest)                 // Recursively heapify the affected subtree
 	}
 }

--- a/sort/sort_test.go
+++ b/sort/sort_test.go
@@ -182,8 +182,7 @@ func BenchmarkSort(b *testing.B) {
 		input := generateRandomSliceInt(bm.size)
 		for _, fn := range sortFns[int]() {
 			b.Run(fn.Name+"-"+bm.name+"("+strconv.Itoa(bm.size)+")", func(b *testing.B) {
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					// Create a fresh copy of the input for each iteration
 					inputCopy := make([]int, len(input))
 					copy(inputCopy, input)

--- a/sort/sort_test.go
+++ b/sort/sort_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func generateRandomSliceInt(size int) []int {
-	max := big.NewInt(1000)
+	maxVal := big.NewInt(1000)
 	slice := make([]int, size)
 
 	for i := 0; i < size; i++ {
-		num, err := rand.Int(rand.Reader, max)
+		num, err := rand.Int(rand.Reader, maxVal)
 		if err != nil {
 			panic(err)
 		}

--- a/sort/sort_test.go
+++ b/sort/sort_test.go
@@ -11,7 +11,7 @@ func generateRandomSliceInt(size int) []int {
 	maxVal := big.NewInt(1000)
 	slice := make([]int, size)
 
-	for i := 0; i < size; i++ {
+	for i := range size {
 		num, err := rand.Int(rand.Reader, maxVal)
 		if err != nil {
 			panic(err)
@@ -26,7 +26,7 @@ func generateRandomSliceFloat(size int) []float64 {
 	maxUint64 := new(big.Int).Lsh(big.NewInt(1), 53) // 2^53 for float64 precision
 	slice := make([]float64, size)
 
-	for i := 0; i < size; i++ {
+	for i := range size {
 		n, err := rand.Int(rand.Reader, maxUint64)
 		if err != nil {
 			panic(err)
@@ -183,9 +183,12 @@ func BenchmarkSort(b *testing.B) {
 		for _, fn := range sortFns[int]() {
 			b.Run(fn.Name+"-"+bm.name+"("+strconv.Itoa(bm.size)+")", func(b *testing.B) {
 				for b.Loop() {
+					b.StopTimer()
 					// Create a fresh copy of the input for each iteration
 					inputCopy := make([]int, len(input))
 					copy(inputCopy, input)
+					b.StartTimer()
+
 					fn.Fn(inputCopy)
 				}
 			})

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -621,15 +621,13 @@ func TestCommonSuffix(t *testing.T) {
 
 func BenchmarkSubstringSearch(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		SubstringSearch("find this in a string", "this", SubstringSearchOptions{
 			CaseInsensitive: false,
 			ReturnIndexes:   false,
 		})
 	}
 }
-
-var _titleLength int
 
 func BenchmarkToTitle(b *testing.B) {
 	const inputString = "this string is primarily lower case and should be Converted to TiTle case"
@@ -658,67 +656,65 @@ func BenchmarkToTitle(b *testing.B) {
 			b.ReportAllocs()
 			b.SetBytes(int64(len(inputString)))
 
-			var title string
-			for range b.N {
-				title = ToTitle(inputString, test)
+			for b.Loop() {
+				_ = ToTitle(inputString, test)
 			}
-			_titleLength = len(title)
 		})
 	}
 }
 
 func BenchmarkTokenize(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		Tokenize("This is a custom-tokenization!example", "-!")
 	}
 }
 
 func BenchmarkRot13Encode(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		Rot13Encode("Hello, World!")
 	}
 }
 
 func BenchmarkCaesarEncrypt(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		CaesarEncrypt("Hello, World!", 3)
 	}
 }
 
 func BenchmarkRunLengthEncode(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		RunLengthEncode("aaabbccccdd")
 	}
 }
 
 func BenchmarkIsValidEmail(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		IsValidEmail("example@email.com")
 	}
 }
 
 func BenchmarkReverse(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		Reverse("hello")
 	}
 }
 
 func BenchmarkCommonPrefix(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		CommonPrefix("nation", "national", "nasty")
 	}
 }
 
 func BenchmarkCommonSuffix(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		CommonSuffix("testing", "running", "jumping")
 	}
 }

--- a/structs/structs_test.go
+++ b/structs/structs_test.go
@@ -152,9 +152,8 @@ func BenchmarkCompareStructsSimple(b *testing.B) {
 	new := Test{Name: "example - updated", Age: 18, IsAdult: true}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := CompareStructs(old, new)
 		if err != nil {
 			b.Fatal(err)
@@ -175,9 +174,8 @@ func BenchmarkCompareStructsComplex(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := CompareStructs(old, new)
 		if err != nil {
 			b.Fatal(err)

--- a/structs/structs_test.go
+++ b/structs/structs_test.go
@@ -110,7 +110,7 @@ func TestCompareStructsWithPointers(t *testing.T) {
 		MyMap:     map[string]string{"k": "v1"},
 	}
 
-	new := ComplexPointerTest{
+	newVal := ComplexPointerTest{
 		Data: PointerTest{
 			Name:         &name2,
 			Age:          &age2,
@@ -133,7 +133,7 @@ func TestCompareStructsWithPointers(t *testing.T) {
 		{FieldName: "map", OldValue: map[string]string{"k": "v1"}, NewValue: map[string]string{"k": "v2"}},
 	}
 
-	got, err := CompareStructs(old, new)
+	got, err := CompareStructs(old, newVal)
 	if err != nil {
 		t.Fatalf("CompareStructs() error: %v", err)
 	}
@@ -148,13 +148,13 @@ func TestCompareStructsWithPointers(t *testing.T) {
 // ================================================================================
 
 func BenchmarkCompareStructsSimple(b *testing.B) {
-	old := Test{Name: "example", Age: 10, IsAdult: false}
-	new := Test{Name: "example - updated", Age: 18, IsAdult: true}
+	oldVal := Test{Name: "example", Age: 10, IsAdult: false}
+	newVal := Test{Name: "example - updated", Age: 18, IsAdult: true}
 
 	b.ReportAllocs()
 
 	for b.Loop() {
-		_, err := CompareStructs(old, new)
+		_, err := CompareStructs(oldVal, newVal)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -162,12 +162,12 @@ func BenchmarkCompareStructsSimple(b *testing.B) {
 }
 
 func BenchmarkCompareStructsComplex(b *testing.B) {
-	old := ComplexTest{
+	oldVal := ComplexTest{
 		Data:      Test{Name: "example1", Age: 25, IsAdult: true},
 		UpdatedOn: time.Date(2024, 10, 22, 0, 0, 0, 0, time.UTC),
 		History:   []string{"user1", "user2"},
 	}
-	new := ComplexTest{
+	newVal := ComplexTest{
 		Data:      Test{Name: "example1", Age: 26, IsAdult: true},
 		UpdatedOn: time.Date(2024, 10, 22, 0, 1, 0, 0, time.UTC),
 		History:   []string{"user1", "user2", "user3"},
@@ -176,7 +176,7 @@ func BenchmarkCompareStructsComplex(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		_, err := CompareStructs(old, new)
+		_, err := CompareStructs(oldVal, newVal)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/templates/html_test.go
+++ b/templates/html_test.go
@@ -224,9 +224,8 @@ func BenchmarkRenderHTML(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var sb strings.Builder
 		_ = tmpl.Execute(&sb, data)
 	}

--- a/templates/text_test.go
+++ b/templates/text_test.go
@@ -185,7 +185,8 @@ func BenchmarkRenderText(b *testing.B) {
 		Date: time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC),
 	}
 
-	for i := 0; i < b.N; i++ {
+	b.ReportAllocs()
+	for b.Loop() {
 		_, _ = RenderText(testTemplate1, data)
 	}
 }

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -924,7 +924,7 @@ func TestSplitDuration(t *testing.T) {
 		{
 			name: "1 day 2 hours 30 minutes 45 seconds",
 			args: args{
-				d: time.Duration(1*24*time.Hour + 2*time.Hour + 30*time.Minute + 45*time.Second),
+				d: 1*24*time.Hour + 2*time.Hour + 30*time.Minute + 45*time.Second,
 			},
 			wantDays:    1,
 			wantHours:   2,
@@ -934,7 +934,7 @@ func TestSplitDuration(t *testing.T) {
 		{
 			name: "3 days 5 hours",
 			args: args{
-				d: time.Duration(3*24*time.Hour + 5*time.Hour),
+				d: 3*24*time.Hour + 5*time.Hour,
 			},
 			wantDays:    3,
 			wantHours:   5,
@@ -944,7 +944,7 @@ func TestSplitDuration(t *testing.T) {
 		{
 			name: "No days, 1 hour 30 minutes",
 			args: args{
-				d: time.Duration(1*time.Hour + 30*time.Minute),
+				d: 1*time.Hour + 30*time.Minute,
 			},
 			wantDays:    0,
 			wantHours:   1,
@@ -954,7 +954,7 @@ func TestSplitDuration(t *testing.T) {
 		{
 			name: "Negative duration",
 			args: args{
-				d: time.Duration(-26 * time.Hour),
+				d: -26 * time.Hour,
 			},
 			wantDays:    -1,
 			wantHours:   -2,

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -412,36 +412,55 @@ func TestGetQueryParamError(t *testing.T) {
 // ================================================================================
 
 func BenchmarkBuildURL(b *testing.B) {
+	var (
+		scheme, host, path = "http", "example.com", "onePath"
+		qp                 = map[string]string{"queryParamOne": "valueQueryParamOne"}
+	)
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, _ = BuildURL("http", "example.com", "onePath", map[string]string{"queryParamOne": "valueQueryParamOne"})
+	for b.Loop() {
+		_, _ = BuildURL(scheme, host, path, qp)
 	}
 }
 
 func BenchmarkAddQueryParams(b *testing.B) {
+	var (
+		urlStr = "http://example.com"
+		qp     = map[string]string{"queryParamOne": "valueQueryParamOne"}
+	)
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, _ = AddQueryParams("http://example.com", map[string]string{"queryParamOne": "valueQueryParamOne"})
+	for b.Loop() {
+		_, _ = AddQueryParams(urlStr, qp)
 	}
 }
 
 func BenchmarkIsValidURL(b *testing.B) {
+	var (
+		urlStr  = "http://example.com"
+		schemes = []string{"http", "https"}
+	)
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		IsValidURL("http://example.com", []string{"http", "https"})
+	for b.Loop() {
+		IsValidURL(urlStr, schemes)
 	}
 }
 
 func BenchmarkExtractDomain(b *testing.B) {
+	urlStr := "http://example.com"
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, _ = ExtractDomain("http://example.com")
+	for b.Loop() {
+		_, _ = ExtractDomain(urlStr)
 	}
 }
 
 func BenchmarkGetQueryParam(b *testing.B) {
+	urlStr, key := "http://example.com?key=value", "key"
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, _ = GetQueryParam("http://example.com?key=value", "key")
+	for b.Loop() {
+		_, _ = GetQueryParam(urlStr, key)
 	}
 }


### PR DESCRIPTION
### Description:
The following has been done::

1. Updated Go to v1.24 and defined toolchain version 1.24.6
2. Updated GitHub Action Workflow to use the same go version as defined in go.mod file.
3. Updated 'preferred Go version' in utility package `README.md`. 
4. Updated benchmark loops to b.Loop() and removed ResetTimer(), since this is now unnecessary.
5. Cleaned up code to avoid variable name collisions with packages and built-in functions (e.g `new` => `newVal`, `hash` => `checksum` etc.)
6. Removed redundant type casting throughout the code.
 
### Checklist:  
- [x] **Tests Passing**: Verify by running `make test`.  
- [x] **Golint Passing**: Confirm by running `make lint`.  

#### If added a new utility function or updated existing function logic:
* [ ] Updated the utility package `EXAMPLES.md`
* [x] Updated the utility package `README.md`

#### If added a new utility package:
* [ ] Updated the main `README.md` utility packages table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Minimum required Go version raised to 1.24 and README updated.

* **Chores**
  * CI now derives the Go toolchain version from the module and includes a toolchain directive for consistent builds.

* **Refactor**
  * Modernized benchmark harnesses across the repo and applied small stylistic cleanups for clarity and deterministic behavior.

* **Tests**
  * Improved test scaffolding and cleanup; added new tests (including a fork-based panic validation, truncation and NaN checks) and generic test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->