### PR TITLE
feat(ratelimiter): add FixedWindow limiter and tests

### DIFF
--- a/ratelimiter/ratelimiter_test.go
+++ b/ratelimiter/ratelimiter_test.go
@@ -389,3 +389,484 @@ func TestTokensNeverNegative(t *testing.T) {
 		t.Errorf("tokens should never be negative, got %v", rl.Tokens())
 	}
 }
+
+// TestFixedWindow_Allow tests the Allow method of the FixedWindow rate limiter.
+// It verifies that requests are allowed up to the limit, blocked after the limit,
+// and allowed again after the interval resets. It also checks default values for invalid parameters.
+func TestFixedWindow_Allow(t *testing.T) {
+	tests := []struct {
+		name     string
+		limit    int
+		interval time.Duration
+		actions  []struct {
+			sleep time.Duration
+			want  bool
+		}
+	}{
+		{
+			name:     "allow up to limit, block after, reset after interval",
+			limit:    2,
+			interval: 50 * time.Millisecond,
+			actions: []struct {
+				sleep time.Duration
+				want  bool
+			}{
+				{0, true},
+				{0, true},
+				{0, false},
+				{60 * time.Millisecond, true},
+			},
+		},
+		{
+			name:     "default values for invalid parameters",
+			limit:    0,
+			interval: 0,
+			actions: []struct {
+				sleep time.Duration
+				want  bool
+			}{
+				{0, true},
+				{0, false},
+				{1100 * time.Millisecond, true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limiter := NewFixedWindow(tt.limit, tt.interval)
+			for i, act := range tt.actions {
+				if act.sleep > 0 {
+					time.Sleep(act.sleep)
+				}
+				got := limiter.Allow()
+				if got != act.want {
+					t.Errorf("action %d: Allow() = %v, want %v", i, got, act.want)
+				}
+			}
+		})
+	}
+}
+
+// TestFixedWindow_Setters tests the SetInterval and SetLimit methods of the FixedWindow rate limiter.
+// It verifies that changing the interval or limit updates the limiter's behavior as expected,
+// including resetting the window and increasing or decreasing the available requests.
+func TestFixedWindow_Setters(t *testing.T) {
+	type step struct {
+		action string
+		value  interface{}
+		sleep  time.Duration
+		want   bool
+	}
+	tests := []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name: "SetInterval resets window",
+			steps: []step{
+				{"allow", nil, 0, true},
+				{"allow", nil, 0, false},
+				{"sleep", nil, 25 * time.Millisecond, false}, // Wait for window to expire
+				{"setInterval", 5 * time.Millisecond, 0, false},
+				{"allow", nil, 0, true}, // Window should be reset since it expired
+			},
+		},
+		{
+			name: "SetLimit increases available requests",
+			steps: []step{
+				{"allow", nil, 0, true},   // count=1, limit=1
+				{"allow", nil, 0, false},  // count=1, limit=1 (blocked)
+				{"setLimit", 3, 0, false}, // count=1, limit=3
+				{"allow", nil, 0, true},   // count=2, limit=3 (allowed)
+				{"allow", nil, 0, true},   // count=3, limit=3 (allowed)
+				{"allow", nil, 0, false},  // count=3, limit=3 (blocked)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limiter := NewFixedWindow(1, 20*time.Millisecond)
+			for i, s := range tt.steps {
+				switch s.action {
+				case "allow":
+					got := limiter.Allow()
+					if got != s.want {
+						t.Errorf("step %d: Allow() = %v, want %v", i, got, s.want)
+					}
+				case "setInterval":
+					limiter.SetInterval(s.value.(time.Duration))
+				case "setLimit":
+					limiter.SetLimit(s.value.(int))
+				case "sleep":
+					time.Sleep(s.sleep)
+				}
+			}
+		})
+	}
+}
+
+// TestNewFixedWindow tests the NewFixedWindow constructor for the FixedWindow rate limiter.
+// It checks that valid and invalid parameters are handled correctly, including default values,
+// and that the initial state of the limiter is as expected.
+func TestNewFixedWindow(t *testing.T) {
+	tests := []struct {
+		name             string
+		limit            int
+		interval         time.Duration
+		expectedLimit    int
+		expectedInterval time.Duration
+	}{
+		{
+			name:             "valid parameters",
+			limit:            10,
+			interval:         5 * time.Second,
+			expectedLimit:    10,
+			expectedInterval: 5 * time.Second,
+		},
+		{
+			name:             "limit less than 1 defaults to 1",
+			limit:            0,
+			interval:         5 * time.Second,
+			expectedLimit:    1,
+			expectedInterval: 5 * time.Second,
+		},
+		{
+			name:             "negative limit defaults to 1",
+			limit:            -5,
+			interval:         5 * time.Second,
+			expectedLimit:    1,
+			expectedInterval: 5 * time.Second,
+		},
+		{
+			name:             "zero interval defaults to 1 second",
+			limit:            10,
+			interval:         0,
+			expectedLimit:    10,
+			expectedInterval: 1 * time.Second,
+		},
+		{
+			name:             "negative interval defaults to 1 second",
+			limit:            10,
+			interval:         -5 * time.Second,
+			expectedLimit:    10,
+			expectedInterval: 1 * time.Second,
+		},
+		{
+			name:             "both invalid parameters use defaults",
+			limit:            0,
+			interval:         0,
+			expectedLimit:    1,
+			expectedInterval: 1 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fw := NewFixedWindow(tt.limit, tt.interval)
+
+			if fw.limit != tt.expectedLimit {
+				t.Errorf("NewFixedWindow() limit = %v, want %v", fw.limit, tt.expectedLimit)
+			}
+			if fw.interval != tt.expectedInterval {
+				t.Errorf("NewFixedWindow() interval = %v, want %v", fw.interval, tt.expectedInterval)
+			}
+			if fw.count != 0 {
+				t.Errorf("NewFixedWindow() count = %v, want 0", fw.count)
+			}
+			// windowEndTime should be approximately now + interval
+			now := time.Now()
+			expectedEnd := now.Add(tt.expectedInterval)
+			if fw.windowEndTime.Before(now) || fw.windowEndTime.After(expectedEnd.Add(10*time.Millisecond)) {
+				t.Errorf("NewFixedWindow() windowEndTime is not properly set")
+			}
+		})
+	}
+}
+
+// TestFixedWindow_Allow_WindowReset tests that the FixedWindow rate limiter resets its window after the interval.
+// It verifies that requests are allowed up to the limit, blocked after the limit, and allowed again after the window resets.
+func TestFixedWindow_Allow_WindowReset(t *testing.T) {
+	limit := 3
+	interval := 50 * time.Millisecond
+	fw := NewFixedWindow(limit, interval)
+
+	// Use up the limit
+	for i := 0; i < limit; i++ {
+		if !fw.Allow() {
+			t.Errorf("Allow() should return true for request %d", i+1)
+		}
+	}
+
+	// Next request should be denied
+	if fw.Allow() {
+		t.Error("Allow() should return false when limit exceeded")
+	}
+
+	// Wait for window to reset
+	time.Sleep(interval + 10*time.Millisecond)
+
+	// Should be able to make requests again
+	for i := 0; i < limit; i++ {
+		if !fw.Allow() {
+			t.Errorf("Allow() should return true after window reset for request %d", i+1)
+		}
+	}
+
+	// And should be denied again
+	if fw.Allow() {
+		t.Error("Allow() should return false when limit exceeded after reset")
+	}
+}
+
+// TestFixedWindow_Allow_ConcurrentAccess tests the FixedWindow rate limiter under concurrent access.
+// It verifies that the limiter allows up to the limit and blocks further requests, even when accessed by multiple goroutines.
+func TestFixedWindow_Allow_ConcurrentAccess(t *testing.T) {
+	limit := 100
+	interval := 100 * time.Millisecond
+	fw := NewFixedWindow(limit, interval)
+
+	// Use channels to coordinate goroutines
+	start := make(chan struct{})
+	results := make(chan bool, limit*2)
+
+	// Start multiple goroutines that will try to acquire tokens
+	for i := 0; i < limit*2; i++ {
+		go func() {
+			<-start // Wait for signal to start
+			results <- fw.Allow()
+		}()
+	}
+
+	// Signal all goroutines to start
+	close(start)
+
+	// Collect results
+	allowed := 0
+	denied := 0
+	for i := 0; i < limit*2; i++ {
+		if <-results {
+			allowed++
+		} else {
+			denied++
+		}
+	}
+
+	// Should have exactly 'limit' allowed and 'limit' denied
+	if allowed != limit {
+		t.Errorf("Expected %d allowed requests, got %d", limit, allowed)
+	}
+	if denied != limit {
+		t.Errorf("Expected %d denied requests, got %d", limit, denied)
+	}
+}
+
+// TestFixedWindow_SetInterval tests the SetInterval method of the FixedWindow rate limiter.
+// It verifies that changing the interval updates the limiter's behavior and resets the window if expired.
+// It also checks that invalid intervals default to 1 second.
+func TestFixedWindow_SetInterval(t *testing.T) {
+	fw := NewFixedWindow(2, 100*time.Millisecond)
+
+	// Use up the limit
+	if !fw.Allow() {
+		t.Fatal("First request should be allowed")
+	}
+	if !fw.Allow() {
+		t.Fatal("Second request should be allowed")
+	}
+	if fw.Allow() {
+		t.Fatal("Should be rate limited")
+	}
+
+	// Wait for window to expire first
+	time.Sleep(110 * time.Millisecond)
+
+	// Change interval to a shorter duration - this will reset the window since it expired
+	newInterval := 20 * time.Millisecond
+	fw.SetInterval(newInterval)
+
+	// Should be allowed now since window was reset
+	if !fw.Allow() {
+		t.Error("Should be allowed after SetInterval when window expired")
+	}
+
+	// Test with invalid interval
+	fw.SetInterval(-5 * time.Second)
+	if fw.interval != 1*time.Second {
+		t.Errorf("Invalid interval should default to 1 second, got %v", fw.interval)
+	}
+}
+
+// TestFixedWindow_SetInterval_WindowReset tests that SetInterval resets the window if it has expired.
+// It verifies that after changing the interval, the limiter allows requests up to the new limit.
+func TestFixedWindow_SetInterval_WindowReset(t *testing.T) {
+	fw := NewFixedWindow(2, 50*time.Millisecond) // Shorter initial interval
+
+	// Use some of the limit
+	fw.Allow()
+
+	// Wait for window to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Change interval - this should reset the window since it expired
+	fw.SetInterval(100 * time.Millisecond)
+
+	// Count should be reset, so we should get the full limit again
+	if !fw.Allow() {
+		t.Error("First request should be allowed after window reset")
+	}
+	if !fw.Allow() {
+		t.Error("Second request should be allowed after window reset")
+	}
+	if fw.Allow() {
+		t.Error("Should be rate limited after using new limit")
+	}
+}
+
+// TestFixedWindow_SetLimit tests the SetLimit method of the FixedWindow rate limiter.
+// It verifies that increasing the limit allows more requests and that invalid limits default to 1.
+func TestFixedWindow_SetLimit(t *testing.T) {
+	fw := NewFixedWindow(2, 100*time.Millisecond)
+
+	// Use up the initial limit
+	if !fw.Allow() {
+		t.Fatal("First request should be allowed")
+	}
+	if !fw.Allow() {
+		t.Fatal("Second request should be allowed")
+	}
+	if fw.Allow() {
+		t.Fatal("Should be rate limited")
+	}
+
+	// Increase the limit
+	fw.SetLimit(4)
+
+	// Should be able to make more requests now (2 more to reach new limit of 4)
+	if !fw.Allow() {
+		t.Error("Third request should be allowed after increasing limit")
+	}
+	if !fw.Allow() {
+		t.Error("Fourth request should be allowed after increasing limit")
+	}
+	if fw.Allow() {
+		t.Error("Should be rate limited after reaching new limit")
+	}
+
+	// Test with invalid limit
+	fw.SetLimit(-5)
+	if fw.limit != 1 {
+		t.Errorf("Invalid limit should default to 1, got %d", fw.limit)
+	}
+}
+
+// TestFixedWindow_SetLimit_WindowReset tests that SetLimit resets the window if it has expired.
+// It verifies that increasing the limit allows more requests within the same window.
+func TestFixedWindow_SetLimit_WindowReset(t *testing.T) {
+	fw := NewFixedWindow(3, 500*time.Millisecond)
+
+	// Use some of the limit
+	fw.Allow()
+	fw.Allow()
+
+	// Wait a bit but not enough for window to reset naturally
+	time.Sleep(50 * time.Millisecond)
+
+	// Change limit - this should reset the window if window has expired
+	fw.SetLimit(5)
+
+	// In this case, window hasn't expired, so count should remain
+	// We should be able to make 1 more request (used 2, limit now 5)
+	if !fw.Allow() {
+		t.Error("Should be allowed within new higher limit")
+	}
+}
+
+// TestFixedWindow_SetLimit_LowerLimit tests lowering the limit below the current count.
+// It verifies that the limiter blocks requests when the count exceeds the new lower limit,
+// and allows requests again after the window resets.
+func TestFixedWindow_SetLimit_LowerLimit(t *testing.T) {
+	fw := NewFixedWindow(5, 100*time.Millisecond)
+
+	// Use some of the limit
+	fw.Allow()
+	fw.Allow()
+	fw.Allow()
+
+	// Lower the limit to below current count
+	fw.SetLimit(2)
+
+	// Should be rate limited since current count (3) > new limit (2)
+	if fw.Allow() {
+		t.Error("Should be rate limited when current count exceeds new limit")
+	}
+
+	// Wait for window to reset
+	time.Sleep(110 * time.Millisecond)
+
+	// Should work with new limit now
+	if !fw.Allow() {
+		t.Error("First request should be allowed after window reset with new limit")
+	}
+	if !fw.Allow() {
+		t.Error("Second request should be allowed after window reset with new limit")
+	}
+	if fw.Allow() {
+		t.Error("Should be rate limited at new limit")
+	}
+}
+
+// TestFixedWindow_EdgeCases tests various edge cases for the FixedWindow rate limiter.
+// It checks zero and negative limits and intervals, as well as rapid successive calls.
+func TestFixedWindow_EdgeCases(t *testing.T) {
+	t.Run("zero and negative limits", func(t *testing.T) {
+		fw1 := NewFixedWindow(0, time.Second)
+		fw2 := NewFixedWindow(-1, time.Second)
+
+		// Both should have limit of 1
+		if !fw1.Allow() {
+			t.Error("Zero limit should default to 1")
+		}
+		if fw1.Allow() {
+			t.Error("Should be rate limited after first request")
+		}
+
+		if !fw2.Allow() {
+			t.Error("Negative limit should default to 1")
+		}
+		if fw2.Allow() {
+			t.Error("Should be rate limited after first request")
+		}
+	})
+
+	t.Run("zero and negative intervals", func(t *testing.T) {
+		fw1 := NewFixedWindow(1, 0)
+		fw2 := NewFixedWindow(1, -time.Second)
+
+		// Both should have interval of 1 second
+		if fw1.interval != time.Second {
+			t.Errorf("Zero interval should default to 1 second, got %v", fw1.interval)
+		}
+		if fw2.interval != time.Second {
+			t.Errorf("Negative interval should default to 1 second, got %v", fw2.interval)
+		}
+	})
+
+	t.Run("rapid successive calls", func(t *testing.T) {
+		fw := NewFixedWindow(1000, 100*time.Millisecond)
+
+		// Make rapid successive calls
+		allowed := 0
+		for i := 0; i < 1500; i++ {
+			if fw.Allow() {
+				allowed++
+			}
+		}
+
+		// Should have allowed exactly 1000
+		if allowed != 1000 {
+			t.Errorf("Expected 1000 allowed requests, got %d", allowed)
+		}
+	})
+}


### PR DESCRIPTION
### Description:
Introduce a Fixed Window rate limiter implementation in ratelimiter package, allowing a fixed number of events per interval. Add comprehensive unit tests covering core behavior, parameter validation, setters, concurrency, and edge cases.

### Checklist:  
- [x] **Tests Passing**: Verify by running `make test`.  
- [x] **Golint Passing**: Confirm by running `make lint`.  

#### If added a new utility function or updated existing function logic:
* [ ] Updated the utility package `EXAMPLES.md`
* [ ] Updated the utility package `README.md`

#### If added a new utility package:
* [ ] Updated the main `README.md` utility packages table
