### PR TITLE
feat(regexamples): add regex example generation package

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ cd utils
 | **queue** | Queue data structure| [README](queue/README.md) | [EXAMPLES](queue/EXAMPLES.md) |
 | **rand**      | Random number and string generation utilities      | [README](rand/README.md)      | [EXAMPLES](rand/EXAMPLES.md)      |
 | **ratelimiter** | Token-bucket rate limiter (allow/wait, adjustable capacity & refill rate) | [README](ratelimiter/README.md) | [EXAMPLES](ratelimiter/EXAMPLES.md) |
+| **regexamples** | Generate random strings that match a given regular expression | [README](regexamples/README.md) | [EXAMPLES](regexamples/EXAMPLES.md) |
 | **slice**     | Slice manipulation and de-duplication utilities    | [README](slice/README.md)     | [EXAMPLES](slice/EXAMPLES.md)     |
 | **slugger**   | A simple and efficient way to generate URL-friendly slugs from strings             | [README](slugger/README.md)       | [EXAMPLES](slugger/EXAMPLES.md)       |
 | **sort**      | Sorting algorithms                                 | [README](sort/README.md)      | [EXAMPLES](sort/EXAMPLES.md)      |

--- a/regexamples/EXAMPLES.md
+++ b/regexamples/EXAMPLES.md
@@ -1,0 +1,227 @@
+## Regex Examples Function Examples
+
+### Generate examples for a digit pattern
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/kashifkhan0771/utils/regexamples"
+)
+
+func main() {
+	examples, err := regexamples.Generate(`\d{4}`, 5)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	for _, s := range examples {
+		fmt.Println(s)
+	}
+}
+```
+
+#### Output:
+
+```
+7392
+0154
+8820
+3467
+5901
+```
+
+---
+
+### Generate examples for a word pattern with a range quantifier
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/kashifkhan0771/utils/regexamples"
+)
+
+func main() {
+	examples, err := regexamples.Generate(`\w{3,6}`, 5)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	for _, s := range examples {
+		fmt.Println(s)
+	}
+}
+```
+
+#### Output:
+
+```
+aB3
+kQz19w
+mR7
+x2Lp
+Tz4kWn
+```
+
+---
+
+### Generate examples for an alternation pattern
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/kashifkhan0771/utils/regexamples"
+)
+
+func main() {
+	examples, err := regexamples.Generate(`(foo|bar|baz)`, 5)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	for _, s := range examples {
+		fmt.Println(s)
+	}
+}
+```
+
+#### Output:
+
+```
+bar
+foo
+baz
+foo
+bar
+```
+
+---
+
+### Generate examples for an email-like pattern
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/kashifkhan0771/utils/regexamples"
+)
+
+func main() {
+	examples, err := regexamples.Generate(`[a-z]{4,8}@[a-z]{3,6}\.(com|net|org)`, 5)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	for _, s := range examples {
+		fmt.Println(s)
+	}
+}
+```
+
+#### Output:
+
+```
+jktr@mxpw.com
+abcdefgh@zlo.net
+pwqr@abcde.org
+mnop@xyz.com
+lkjh@qrst.net
+```
+
+---
+
+### Reuse a Generator for multiple batches
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/kashifkhan0771/utils/regexamples"
+)
+
+func main() {
+	g, err := regexamples.NewGenerator(`[A-Z]{2}\d{4}`)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	for range 3 {
+		batch, err := g.Generate(3)
+		if err != nil {
+			fmt.Println("Error:", err)
+			return
+		}
+
+		fmt.Println(batch)
+	}
+}
+```
+
+#### Output:
+
+```
+[KT8301 PX4720 BN0093]
+[ZA1154 MQ6688 RL2279]
+[CF9900 YD3341 WS7712]
+```
+
+---
+
+### Deterministic generation with SetSeed
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/kashifkhan0771/utils/regexamples"
+)
+
+func main() {
+	g, err := regexamples.NewGenerator(`[a-z]{5}-\d{3}`)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	g.SetSeed(42)
+
+	examples, err := g.Generate(3)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	for _, s := range examples {
+		fmt.Println(s)
+	}
+}
+```
+
+#### Output:
+
+```
+mxkqr-581
+azpwt-047
+lbnvc-923
+```
+
+---

--- a/regexamples/README.md
+++ b/regexamples/README.md
@@ -1,0 +1,12 @@
+### Regex Examples (regexamples)
+
+- **Generate**: Generates n random strings that match the given regular expression pattern.
+- **NewGenerator**: Compiles a regex pattern into a reusable Generator, avoiding repeated parsing overhead when generating multiple batches.
+- **Generator.Generate**: Generates n matching strings from a pre-compiled Generator.
+- **Generator.SetSeed**: Sets a deterministic seed on the Generator so that subsequent calls produce the same sequence of strings.
+
+## Examples:
+
+For examples of each function, please checkout [EXAMPLES.md](/regexamples/EXAMPLES.md)
+
+---

--- a/regexamples/README.md
+++ b/regexamples/README.md
@@ -7,6 +7,6 @@
 
 ## Examples:
 
-For examples of each function, please checkout [EXAMPLES.md](/regexamples/EXAMPLES.md)
+For examples of each function, please checkout [EXAMPLES.md](./EXAMPLES.md)
 
 ---

--- a/regexamples/regexamples.go
+++ b/regexamples/regexamples.go
@@ -1,0 +1,295 @@
+// Package regexamples generates random strings that match a given regular expression.
+package regexamples
+
+import (
+	"fmt"
+	"math"
+	randv2 "math/rand/v2"
+	"regexp/syntax"
+	"strings"
+	"unicode"
+)
+
+const (
+	// DefaultMaxRepeat is the default cap for unbounded quantifiers (*, +, and {n,} without upper bound).
+	DefaultMaxRepeat = 10
+
+	printableMin rune = 32  // space
+	printableMax rune = 126 // tilde (~)
+)
+
+// Generator holds a compiled pattern and a random source, and can produce
+// multiple matching strings efficiently.
+type Generator struct {
+	re  *syntax.Regexp
+	rng *randv2.Rand
+}
+
+// NewGenerator compiles pattern and returns a Generator ready to produce
+// matching strings. Returns an error if the pattern is invalid.
+func NewGenerator(pattern string) (*Generator, error) {
+	re, err := syntax.Parse(pattern, syntax.Perl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex pattern: %w", err)
+	}
+
+	return &Generator{
+		re:  re.Simplify(),
+		rng: randv2.New(randv2.NewPCG(randv2.Uint64(), randv2.Uint64())), //nolint:gosec
+	}, nil
+}
+
+// SetSeed resets the generator's random source to a deterministic seed,
+// which makes subsequent Generate calls produce the same sequence of strings.
+func (g *Generator) SetSeed(seed uint64) {
+	// #nosec G404 -- not used for security
+	g.rng = randv2.New(randv2.NewPCG(seed, seed))
+}
+
+// Generate returns n strings that each match the compiled pattern.
+// Returns an error if n is negative or if the pattern cannot be satisfied.
+func (g *Generator) Generate(n int) ([]string, error) {
+	if n < 0 {
+		return nil, fmt.Errorf("n cannot be negative: %d", n)
+	}
+
+	if n == 0 {
+		return []string{}, nil
+	}
+
+	results := make([]string, n)
+
+	for i := range n {
+		var sb strings.Builder
+
+		if err := g.generate(g.re, &sb); err != nil {
+			return nil, fmt.Errorf("failed to generate example %d: %w", i+1, err)
+		}
+
+		results[i] = sb.String()
+	}
+
+	return results, nil
+}
+
+// Generate is a convenience function that compiles pattern and returns n
+// matching strings. For repeated generation from the same pattern prefer
+// NewGenerator to avoid recompiling on every call.
+func Generate(pattern string, n int) ([]string, error) {
+	g, err := NewGenerator(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	return g.Generate(n)
+}
+
+// generate recursively walks the regex AST and writes a matching string into sb.
+func (g *Generator) generate(re *syntax.Regexp, sb *strings.Builder) error {
+	switch re.Op {
+	case syntax.OpLiteral:
+		for _, r := range re.Rune {
+			if re.Flags&syntax.FoldCase != 0 {
+				if g.rng.IntN(2) == 0 {
+					sb.WriteRune(unicode.ToUpper(r))
+				} else {
+					sb.WriteRune(unicode.ToLower(r))
+				}
+			} else {
+				sb.WriteRune(r)
+			}
+		}
+
+	case syntax.OpCharClass:
+		r, err := g.pickFromCharClass(re.Rune)
+		if err != nil {
+			return err
+		}
+
+		sb.WriteRune(r)
+
+	case syntax.OpAnyCharNotNL:
+		sb.WriteRune(g.randPrintableExcluding('\n'))
+
+	case syntax.OpAnyChar:
+		sb.WriteRune(g.randPrintable())
+
+	case syntax.OpQuest:
+		if g.rng.IntN(2) == 0 {
+			if err := g.generate(re.Sub[0], sb); err != nil {
+				return err
+			}
+		}
+
+	case syntax.OpStar:
+		count := g.rng.IntN(DefaultMaxRepeat + 1)
+		for range count {
+			if err := g.generate(re.Sub[0], sb); err != nil {
+				return err
+			}
+		}
+
+	case syntax.OpPlus:
+		count := g.rng.IntN(DefaultMaxRepeat) + 1
+		for range count {
+			if err := g.generate(re.Sub[0], sb); err != nil {
+				return err
+			}
+		}
+
+	case syntax.OpRepeat:
+		min, max := re.Min, re.Max
+		if max == -1 {
+			max = min + DefaultMaxRepeat
+		}
+
+		count := min
+		if max > min {
+			count = min + g.rng.IntN(max-min+1)
+		}
+
+		for range count {
+			if err := g.generate(re.Sub[0], sb); err != nil {
+				return err
+			}
+		}
+
+	case syntax.OpConcat:
+		for _, sub := range re.Sub {
+			if err := g.generate(sub, sb); err != nil {
+				return err
+			}
+		}
+
+	case syntax.OpAlternate:
+		if len(re.Sub) == 0 {
+			return nil // empty alternation matches empty string
+		}
+		idx := g.rng.IntN(len(re.Sub))
+		if err := g.generate(re.Sub[idx], sb); err != nil {
+			return err
+		}
+
+	case syntax.OpCapture:
+		if err := g.generate(re.Sub[0], sb); err != nil {
+			return err
+		}
+
+	case syntax.OpBeginText, syntax.OpEndText,
+		syntax.OpBeginLine, syntax.OpEndLine,
+		syntax.OpWordBoundary, syntax.OpNoWordBoundary:
+		// Anchors and boundaries assert position — they produce no characters.
+
+	case syntax.OpEmptyMatch:
+		// Nothing to emit.
+
+	case syntax.OpNoMatch:
+		return fmt.Errorf("pattern contains a never-matching expression")
+
+	default:
+		return fmt.Errorf("unsupported regex operation: %v", re.Op)
+	}
+
+	return nil
+}
+
+// pickFromCharClass selects a random rune from a character class.
+//
+// The Rune slice in an OpCharClass node stores consecutive [lo, hi] inclusive
+// rune-range pairs (as computed by regexp/syntax, including complement ranges
+// for negated classes like [^0-9]).
+//
+// We first try to pick from the intersection of those ranges with the printable
+// ASCII band [32, 126]. This keeps output human-readable and avoids emitting
+// control characters or high Unicode codepoints from broad negated classes.
+// If the intersection is empty we fall back to the full ranges.
+func (g *Generator) pickFromCharClass(ranges []rune) (rune, error) {
+	// Build the intersection with printable ASCII.
+	printable := intersectWithPrintable(ranges)
+	if len(printable) > 0 {
+		return g.pickFromRanges(printable), nil
+	}
+
+	// Fallback: pick directly from the raw ranges (may include non-ASCII).
+	total := countRunes(ranges)
+	if total == 0 {
+		return 0, fmt.Errorf("character class matches no characters")
+	}
+
+	return g.pickFromRanges(ranges), nil
+}
+
+// intersectWithPrintable clips each [lo, hi] pair in ranges to [printableMin, printableMax]
+// and returns the resulting (possibly empty) list of clipped pairs.
+func intersectWithPrintable(ranges []rune) []rune {
+	var result []rune
+
+	for i := 0; i < len(ranges); i += 2 {
+		lo, hi := ranges[i], ranges[i+1]
+
+		if lo > printableMax || hi < printableMin {
+			continue // entirely outside printable band
+		}
+
+		if lo < printableMin {
+			lo = printableMin
+		}
+
+		if hi > printableMax {
+			hi = printableMax
+		}
+
+		result = append(result, lo, hi)
+	}
+
+	return result
+}
+
+// pickFromRanges picks a uniformly random rune from a list of [lo, hi] pairs.
+func (g *Generator) pickFromRanges(ranges []rune) rune {
+	total := countRunes(ranges)
+	n := g.rng.IntN(total)
+
+	for i := 0; i < len(ranges); i += 2 {
+		size := int(ranges[i+1]-ranges[i]) + 1
+		if n < size {
+			if n < 0 || n > math.MaxInt32 {
+				return 0
+			}
+
+			return ranges[i] + rune(n)
+		}
+
+		n -= size
+	}
+
+	return ranges[0]
+}
+
+// countRunes returns the total number of runes covered by the [lo, hi] pairs.
+func countRunes(ranges []rune) int {
+	total := 0
+	for i := 0; i < len(ranges); i += 2 {
+		total += int(ranges[i+1]-ranges[i]) + 1
+	}
+
+	return total
+}
+
+func (g *Generator) randPrintable() rune {
+	val := g.rng.IntN(int(printableMax - printableMin + 1))
+	if val < 0 || val > math.MaxInt32 {
+		return 0
+	}
+
+	return printableMin + rune(val)
+}
+
+func (g *Generator) randPrintableExcluding(exclude rune) rune {
+	for {
+		r := g.randPrintable()
+		if r != exclude {
+			return r
+		}
+	}
+}

--- a/regexamples/regexamples.go
+++ b/regexamples/regexamples.go
@@ -3,7 +3,6 @@ package regexamples
 
 import (
 	"fmt"
-	"math"
 	randv2 "math/rand/v2"
 	"regexp/syntax"
 	"strings"
@@ -20,6 +19,10 @@ const (
 
 // Generator holds a compiled pattern and a random source, and can produce
 // multiple matching strings efficiently.
+//
+// A Generator is not safe for concurrent use. If you need to generate strings
+// from multiple goroutines, create a separate Generator per goroutine or
+// protect access with a sync.Mutex.
 type Generator struct {
 	re  *syntax.Regexp
 	rng *randv2.Rand
@@ -216,7 +219,7 @@ func (g *Generator) pickFromCharClass(ranges []rune) (rune, error) {
 		return 0, fmt.Errorf("character class matches no characters")
 	}
 
-	return g.pickFromRanges(ranges), nil
+	return g.pickFromRangesN(ranges, total), nil
 }
 
 // intersectWithPrintable clips each [lo, hi] pair in ranges to [printableMin, printableMax]
@@ -247,16 +250,15 @@ func intersectWithPrintable(ranges []rune) []rune {
 
 // pickFromRanges picks a uniformly random rune from a list of [lo, hi] pairs.
 func (g *Generator) pickFromRanges(ranges []rune) rune {
-	total := countRunes(ranges)
+	return g.pickFromRangesN(ranges, countRunes(ranges))
+}
+
+func (g *Generator) pickFromRangesN(ranges []rune, total int) rune {
 	n := g.rng.IntN(total)
 
 	for i := 0; i < len(ranges); i += 2 {
 		size := int(ranges[i+1]-ranges[i]) + 1
 		if n < size {
-			if n < 0 || n > math.MaxInt32 {
-				return 0
-			}
-
 			return ranges[i] + rune(n)
 		}
 
@@ -277,12 +279,7 @@ func countRunes(ranges []rune) int {
 }
 
 func (g *Generator) randPrintable() rune {
-	val := g.rng.IntN(int(printableMax - printableMin + 1))
-	if val < 0 || val > math.MaxInt32 {
-		return 0
-	}
-
-	return printableMin + rune(val)
+	return printableMin + rune(g.rng.IntN(int(printableMax-printableMin+1)))
 }
 
 func (g *Generator) randPrintableExcluding(exclude rune) rune {

--- a/regexamples/regexamples_test.go
+++ b/regexamples/regexamples_test.go
@@ -1,0 +1,260 @@
+package regexamples
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		pattern   string
+		n         int
+		wantErr   bool
+		wantLen   int
+		mustMatch bool
+	}{
+		{
+			name:      "zero examples",
+			pattern:   `\d+`,
+			n:         0,
+			wantLen:   0,
+			mustMatch: false,
+		},
+		{
+			name:      "digits",
+			pattern:   `\d+`,
+			n:         5,
+			wantLen:   5,
+			mustMatch: true,
+		},
+		{
+			name:      "word characters with range",
+			pattern:   `\w{3,6}`,
+			n:         10,
+			wantLen:   10,
+			mustMatch: true,
+		},
+		{
+			name:      "alternation",
+			pattern:   `(foo|bar|baz)`,
+			n:         10,
+			wantLen:   10,
+			mustMatch: true,
+		},
+		{
+			name:      "literal",
+			pattern:   `hello`,
+			n:         3,
+			wantLen:   3,
+			mustMatch: true,
+		},
+		{
+			name:      "optional character",
+			pattern:   `colou?r`,
+			n:         10,
+			wantLen:   10,
+			mustMatch: true,
+		},
+		{
+			name:      "alphanumeric character class",
+			pattern:   `[a-zA-Z0-9]+`,
+			n:         5,
+			wantLen:   5,
+			mustMatch: true,
+		},
+		{
+			name:      "negated character class",
+			pattern:   `[^0-9]{4}`,
+			n:         5,
+			wantLen:   5,
+			mustMatch: true,
+		},
+		{
+			name:      "dot any char",
+			pattern:   `.{5}`,
+			n:         5,
+			wantLen:   5,
+			mustMatch: true,
+		},
+		{
+			name:      "anchors are ignored",
+			pattern:   `^\d{3}$`,
+			n:         5,
+			wantLen:   5,
+			mustMatch: true,
+		},
+		{
+			name:      "exact repetition",
+			pattern:   `a{5}`,
+			n:         3,
+			wantLen:   3,
+			mustMatch: true,
+		},
+		{
+			name:      "email-like pattern",
+			pattern:   `[a-z]{3,8}@[a-z]{3,6}\.(com|net|org)`,
+			n:         5,
+			wantLen:   5,
+			mustMatch: true,
+		},
+		{
+			name:      "star quantifier",
+			pattern:   `ab*c`,
+			n:         10,
+			wantLen:   10,
+			mustMatch: true,
+		},
+		{
+			name:      "plus quantifier",
+			pattern:   `ab+c`,
+			n:         10,
+			wantLen:   10,
+			mustMatch: true,
+		},
+		{
+			name:      "word boundary anchors",
+			pattern:   `\bword\b`,
+			n:         3,
+			wantLen:   3,
+			mustMatch: true,
+		},
+		{
+			name:    "negative n",
+			pattern: `\d+`,
+			n:       -1,
+			wantErr: true,
+		},
+		{
+			name:    "invalid pattern",
+			pattern: `[invalid`,
+			n:       5,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			results, err := Generate(tt.pattern, tt.n)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Generate(%q, %d): expected error, got nil", tt.pattern, tt.n)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Generate(%q, %d): unexpected error: %v", tt.pattern, tt.n, err)
+			}
+
+			if len(results) != tt.wantLen {
+				t.Errorf("Generate(%q, %d): got %d results, want %d", tt.pattern, tt.n, len(results), tt.wantLen)
+			}
+
+			if tt.mustMatch {
+				re := regexp.MustCompile(tt.pattern)
+
+				for i, s := range results {
+					if !re.MatchString(s) {
+						t.Errorf("result[%d] = %q does not match pattern %q", i, s, tt.pattern)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewGenerator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid pattern returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewGenerator(`(unclosed`)
+		if err == nil {
+			t.Error("NewGenerator: expected error for invalid pattern, got nil")
+		}
+	})
+
+	t.Run("reuse generator", func(t *testing.T) {
+		t.Parallel()
+
+		g, err := NewGenerator(`\d{4}`)
+		if err != nil {
+			t.Fatalf("NewGenerator: unexpected error: %v", err)
+		}
+
+		re := regexp.MustCompile(`\d{4}`)
+
+		for range 20 {
+			results, err := g.Generate(3)
+			if err != nil {
+				t.Fatalf("Generate: unexpected error: %v", err)
+			}
+
+			for _, s := range results {
+				if !re.MatchString(s) {
+					t.Errorf("%q does not match pattern", s)
+				}
+			}
+		}
+	})
+}
+
+func TestGeneratorSetSeed(t *testing.T) {
+	t.Parallel()
+
+	pattern := `[a-z]{5}-\d{3}`
+
+	g1, err := NewGenerator(pattern)
+	if err != nil {
+		t.Fatalf("NewGenerator: unexpected error: %v", err)
+	}
+
+	g1.SetSeed(42)
+	results1, err := g1.Generate(10)
+	if err != nil {
+		t.Fatalf("g1.Generate: unexpected error: %v", err)
+	}
+
+	g2, err := NewGenerator(pattern)
+	if err != nil {
+		t.Fatalf("NewGenerator: unexpected error: %v", err)
+	}
+
+	g2.SetSeed(42)
+	results2, err := g2.Generate(10)
+	if err != nil {
+		t.Fatalf("g2.Generate: unexpected error: %v", err)
+	}
+
+	for i := range results1 {
+		if results1[i] != results2[i] {
+			t.Errorf("SetSeed(42): result[%d] differs: %q vs %q", i, results1[i], results2[i])
+		}
+	}
+}
+
+func TestPrintableOutput(t *testing.T) {
+	t.Parallel()
+
+	// Negated digit class — must stay in printable ASCII range.
+	results, err := Generate(`[^0-9]{10}`, 20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, s := range results {
+		for _, r := range s {
+			if r < printableMin || r > printableMax {
+				t.Errorf("result %q contains non-printable rune %U", s, r)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds a new `regexamples` package that generates random strings matching a given regular expression. Supports all common regex constructs via Go's stdlib `regexp/syntax` AST walker, restricts output to printable ASCII, and exposes both a one-shot `Generate` function and a reusable `Generator` type with optional deterministic seeding via `SetSeed`.

### Description:
Explain the purpose of the PR.

### Checklist:  
- [ ] **Tests Passing**: Verify by running `make test`.  
- [ ] **Golint Passing**: Confirm by running `make lint`.  

#### If added a new utility function or updated existing function logic:
* [ ] Updated the utility package `EXAMPLES.md`
* [ ] Updated the utility package `README.md`

#### If added a new utility package:
* [ ] Updated the main `README.md` utility packages table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add regex-based string generation to produce random strings matching provided patterns.
  * Add reusable generators for efficient batch production.
  * Add seed control for deterministic, reproducible outputs.

* **Documentation**
  * Add detailed README and a dedicated examples document with runnable usage snippets and sample outputs.

* **Tests**
  * Add unit tests covering generation, reuse, determinism, input validation, and printable output constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->